### PR TITLE
Close #26: Add WithOnError callback option

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,12 +58,16 @@ The first request executes the handler and caches the response. Subsequent reque
 | `WithKeyHeader(h)` | `"Idempotency-Key"` | Header name to read the idempotency key from |
 | `WithTTL(d)` | `24h` | Cache duration for stored responses |
 | `WithStorage(s)` | In-memory | Storage backend for cached responses |
+| `WithOnError(fn)` | `nil` | Callback invoked when a storage operation fails |
 
 ```go
 mw := idem.New(
 	idem.WithKeyHeader("X-Request-Id"),
 	idem.WithTTL(1 * time.Hour),
 	idem.WithStorage(redisStore),
+	idem.WithOnError(func(err error) {
+		log.Printf("storage error: %v", err)
+	}),
 )
 ```
 

--- a/middleware.go
+++ b/middleware.go
@@ -22,6 +22,9 @@ func (m *Middleware) Handler() func(http.Handler) http.Handler {
 
 			cached, err := m.cfg.storage.Get(r.Context(), key)
 			if err != nil {
+				if m.cfg.onError != nil {
+					m.cfg.onError(err)
+				}
 				next.ServeHTTP(w, r)
 				return
 			}
@@ -35,7 +38,11 @@ func (m *Middleware) Handler() func(http.Handler) http.Handler {
 			next.ServeHTTP(rec, r)
 
 			res := rec.toResponse()
-			_ = m.cfg.storage.Set(r.Context(), key, res, m.cfg.ttl)
+			if err := m.cfg.storage.Set(r.Context(), key, res, m.cfg.ttl); err != nil {
+				if m.cfg.onError != nil {
+					m.cfg.onError(err)
+				}
+			}
 
 			rec.flush()
 		})

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -215,6 +215,55 @@ func TestMiddleware_Handler(t *testing.T) {
 			t.Errorf("status = %d, want %d", rec.Code, http.StatusOK)
 		}
 	})
+
+	t.Run("calls onError callback when storage Get fails", func(t *testing.T) {
+		t.Parallel()
+
+		getErr := errors.New("get failed")
+		var gotErr error
+		handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		})
+
+		store := &errorStorage{getErr: getErr}
+		mw := New(WithStorage(store), WithOnError(func(err error) { gotErr = err }))
+		wrapped := mw.Handler()(handler)
+
+		req := httptest.NewRequest(http.MethodPost, "/", nil)
+		req.Header.Set("Idempotency-Key", "err-key")
+		wrapped.ServeHTTP(httptest.NewRecorder(), req)
+
+		if !errors.Is(gotErr, getErr) {
+			t.Errorf("onError received %v, want %v", gotErr, getErr)
+		}
+	})
+
+	t.Run("calls onError callback when storage Set fails", func(t *testing.T) {
+		t.Parallel()
+
+		setErr := errors.New("set failed")
+		var gotErr error
+		handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		})
+
+		store := &errorStorage{setErr: setErr}
+		mw := New(WithStorage(store), WithOnError(func(err error) { gotErr = err }))
+		wrapped := mw.Handler()(handler)
+
+		req := httptest.NewRequest(http.MethodPost, "/", nil)
+		req.Header.Set("Idempotency-Key", "err-key")
+		rec := httptest.NewRecorder()
+		wrapped.ServeHTTP(rec, req)
+
+		if !errors.Is(gotErr, setErr) {
+			t.Errorf("onError received %v, want %v", gotErr, setErr)
+		}
+
+		if rec.Code != http.StatusOK {
+			t.Errorf("status = %d, want %d", rec.Code, http.StatusOK)
+		}
+	})
 }
 
 // spyStorage tracks Get/Set call counts.

--- a/option.go
+++ b/option.go
@@ -14,6 +14,7 @@ type config struct {
 	keyHeader string
 	ttl       time.Duration
 	storage   Storage
+	onError   func(error)
 }
 
 // defaultConfig returns a config with sensible defaults.
@@ -47,5 +48,12 @@ func WithTTL(ttl time.Duration) Option {
 func WithStorage(s Storage) Option {
 	return func(c *config) {
 		c.storage = s
+	}
+}
+
+// WithOnError specifies a callback function that is called when a storage operation fails.
+func WithOnError(fn func(error)) Option {
+	return func(c *config) {
+		c.onError = fn
 	}
 }

--- a/option_test.go
+++ b/option_test.go
@@ -30,6 +30,10 @@ func TestDefaultConfig(t *testing.T) {
 	if cfg.storage != nil {
 		t.Errorf("storage = %v, want nil", cfg.storage)
 	}
+
+	if cfg.onError != nil {
+		t.Error("onError is non-nil, want nil")
+	}
 }
 
 func TestWithKeyHeader(t *testing.T) {
@@ -104,5 +108,25 @@ func TestWithStorage(t *testing.T) {
 
 	if cfg.storage != stub {
 		t.Errorf("storage = %v, want %v", cfg.storage, stub)
+	}
+}
+
+func TestWithOnError(t *testing.T) {
+	t.Parallel()
+
+	cfg := defaultConfig()
+
+	called := false
+	fn := func(_ error) { called = true }
+	WithOnError(fn)(cfg)
+
+	if cfg.onError == nil {
+		t.Fatal("onError = nil, want non-nil")
+	}
+
+	cfg.onError(nil)
+
+	if !called {
+		t.Error("callback was not called")
 	}
 }


### PR DESCRIPTION
## Summary
- Add `WithOnError(func(error))` option to configure a callback for storage operation failures
- Invoke the callback on `Storage.Get` and `Storage.Set` errors in the middleware
- Maintain existing behavior when no callback is set (fall through on Get error, ignore Set error)
- Add unit tests for the option and middleware error callback paths
- Update README with `WithOnError` documentation and usage example

## Test plan
- [x] `TestWithOnError` verifies the callback is set on config
- [x] `TestDefaultConfig` verifies `onError` defaults to nil
- [x] Middleware test: callback called with correct error on `Get` failure
- [x] Middleware test: callback called with correct error on `Set` failure, response still returned
- [x] Existing test: no panic when `onError` is nil and `Get` fails
- [x] All tests pass with `-race` flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)