### PR TITLE
Close #10: Add Chi router example

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ make shell          # Interactive bash in container
 - **Root package (`idem`)**: Core types and middleware — `idem.go`, `middleware.go`, `storage.go`, `response.go`, `option.go`
 - **`memory/`**: In-memory storage implementation
 - **`redis/`**: Redis storage implementation
-- **`_examples/`**: Framework-specific usage examples (Gin/Echo available, Chi planned)
+- **`_examples/`**: Framework-specific usage examples (Gin, Echo, Chi)
 
 Key interfaces:
 - `Storage` — `Get`/`Set` for cached responses (pluggable backend)

--- a/README.md
+++ b/README.md
@@ -171,12 +171,30 @@ curl -X POST http://localhost:8080/orders -H "Idempotency-Key: key-123"
 
 See [`_examples/echo/main.go`](./_examples/echo/main.go) for the full source including global and route-group middleware patterns.
 
+### Chi
+
+```bash
+cd _examples/chi && go run main.go
+```
+
+```bash
+# First request — handler executes and response is cached
+curl -X POST http://localhost:8080/orders -H "Idempotency-Key: key-123"
+# => {"message":"order created","order_id":"order-1"}
+
+# Second request — cached response returned, handler is NOT re-executed
+curl -X POST http://localhost:8080/orders -H "Idempotency-Key: key-123"
+# => {"message":"order created","order_id":"order-1"}
+```
+
+See [`_examples/chi/main.go`](./_examples/chi/main.go) for the full source including inline (`r.With()`) and route-group middleware patterns.
+
 ## Roadmap
 
 | Phase | Status | Description |
 |-------|--------|-------------|
 | v0.1 | Planned | Core middleware + in-memory storage |
 | v0.2 | **Done** | Redis storage |
-| v0.3 | **In Progress** | Framework examples (Gin / Echo / Chi) |
+| v0.3 | **Done** | Framework examples (Gin / Echo / Chi) |
 | v0.4 | Planned | Concurrent request handling (lock mechanism) |
 | v1.0 | Planned | Documentation + stable release |

--- a/_examples/chi/go.mod
+++ b/_examples/chi/go.mod
@@ -1,0 +1,10 @@
+module github.com/bright-room/idem/_examples/chi
+
+go 1.25.5
+
+require (
+	github.com/bright-room/idem v0.2.0
+	github.com/go-chi/chi/v5 v5.2.1
+)
+
+replace github.com/bright-room/idem => ../../

--- a/_examples/chi/go.sum
+++ b/_examples/chi/go.sum
@@ -1,0 +1,2 @@
+github.com/go-chi/chi/v5 v5.2.1 h1:KOIHODQj58PmL80G2Eak4WdvUzjSJSm0vG72crDCqb8=
+github.com/go-chi/chi/v5 v5.2.1/go.mod h1:L2yAIGWB3H+phAw1NxKwWM+7eUH/lU8pOMm5hHcoops=

--- a/_examples/chi/main.go
+++ b/_examples/chi/main.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sync/atomic"
+
+	"github.com/bright-room/idem"
+	"github.com/go-chi/chi/v5"
+	"github.com/go-chi/chi/v5/middleware"
+)
+
+func main() {
+	idempotency := idem.New()
+
+	r := chi.NewRouter()
+	r.Use(middleware.Logger)
+
+	var orderCount atomic.Int64
+	var paymentCount atomic.Int64
+
+	// Pattern 1: Apply to a specific route inline using r.With().
+	// Chi is net/http compatible, so mw.Handler() works directly
+	// — no wrapper or conversion needed.
+	r.With(idempotency.Handler()).Post("/orders", func(w http.ResponseWriter, r *http.Request) {
+		n := orderCount.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		json.NewEncoder(w).Encode(map[string]string{
+			"order_id": fmt.Sprintf("order-%d", n),
+			"message":  "order created",
+		})
+	})
+
+	// Pattern 2: Apply to a route group.
+	r.Route("/api", func(api chi.Router) {
+		api.Use(idempotency.Handler())
+		api.Post("/payments", func(w http.ResponseWriter, r *http.Request) {
+			n := paymentCount.Add(1)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			json.NewEncoder(w).Encode(map[string]string{
+				"payment_id": fmt.Sprintf("payment-%d", n),
+				"message":    "payment processed",
+			})
+		})
+	})
+
+	// This endpoint has no idempotency middleware.
+	r.Get("/health", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+	})
+
+	http.ListenAndServe(":8080", r)
+}


### PR DESCRIPTION
## Summary
- Add runnable Chi example in `_examples/chi/` with independent Go module
- Demonstrate two middleware patterns: inline per-route (`r.With(mw.Handler()).Post(...)`) and route-group (`r.Route` + `api.Use(mw.Handler())`)
- Chi is `net/http` compatible so `mw.Handler()` works directly — no wrapper or conversion needed (simplest of all three framework examples)
- Update README.md Examples section with Chi usage and mark v0.3 roadmap as **Done**
- Update CLAUDE.md architecture section to reflect all framework examples available

## Test plan
- [ ] `cd _examples/chi && go build ./...` compiles successfully
- [ ] `go run main.go` starts the server on :8080
- [ ] `curl -X POST localhost:8080/orders -H "Idempotency-Key: k1"` returns `order-1`
- [ ] Repeating the same curl returns the same cached response (order-1, not order-2)
- [ ] `curl -X POST localhost:8080/api/payments -H "Idempotency-Key: p1"` works with group middleware
- [ ] `curl localhost:8080/health` works without idempotency header

🤖 Generated with [Claude Code](https://claude.com/claude-code)