### PR TITLE
Close #27: Add option validation to New()

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,13 +25,17 @@ package main
 
 import (
 	"fmt"
+	"log"
 	"net/http"
 
 	"github.com/bright-room/idem"
 )
 
 func main() {
-	mw := idem.New()
+	mw, err := idem.New()
+	if err != nil {
+		log.Fatal(err)
+	}
 
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintln(w, "order created")
@@ -61,7 +65,7 @@ The first request executes the handler and caches the response. Subsequent reque
 | `WithOnError(fn)` | `nil` | Callback invoked when a storage operation fails |
 
 ```go
-mw := idem.New(
+mw, err := idem.New(
 	idem.WithKeyHeader("X-Request-Id"),
 	idem.WithTTL(1 * time.Hour),
 	idem.WithStorage(redisStore),
@@ -69,7 +73,12 @@ mw := idem.New(
 		log.Printf("storage error: %v", err)
 	}),
 )
+if err != nil {
+	log.Fatal(err)
+}
 ```
+
+`New` validates the configuration and returns an error for invalid values such as an empty key header or a non-positive TTL.
 
 ## How It Works
 
@@ -105,7 +114,7 @@ When the `Storage` implementation also implements the `Locker` interface, the mi
 Used automatically when no storage is specified. Suitable for development, testing, and single-instance deployments.
 
 ```go
-mw := idem.New() // uses in-memory storage
+mw, err := idem.New() // uses in-memory storage
 ```
 
 ### Redis
@@ -122,7 +131,7 @@ import (
 client := goredis.NewClient(&goredis.Options{Addr: "localhost:6379"})
 store := idemredis.New(client)
 
-mw := idem.New(idem.WithStorage(store))
+mw, err := idem.New(idem.WithStorage(store))
 ```
 
 ### Custom Storage

--- a/_examples/chi/main.go
+++ b/_examples/chi/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"log"
 	"net/http"
 	"sync/atomic"
 
@@ -12,7 +13,10 @@ import (
 )
 
 func main() {
-	idempotency := idem.New()
+	idempotency, err := idem.New()
+	if err != nil {
+		log.Fatal(err)
+	}
 
 	r := chi.NewRouter()
 	r.Use(middleware.Logger)

--- a/_examples/echo/main.go
+++ b/_examples/echo/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"log"
 	"net/http"
 	"sync/atomic"
 
@@ -11,7 +12,10 @@ import (
 )
 
 func main() {
-	idempotency := idem.New()
+	idempotency, err := idem.New()
+	if err != nil {
+		log.Fatal(err)
+	}
 
 	e := echo.New()
 	e.Use(middleware.Logger())

--- a/_examples/gin/main.go
+++ b/_examples/gin/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"log"
 	"net/http"
 	"sync/atomic"
 
@@ -10,7 +11,10 @@ import (
 )
 
 func main() {
-	idempotency := idem.New()
+	idempotency, err := idem.New()
+	if err != nil {
+		log.Fatal(err)
+	}
 	wrap := wrapMiddleware(idempotency)
 
 	r := gin.Default()

--- a/idem.go
+++ b/idem.go
@@ -7,17 +7,23 @@ import (
 )
 
 // New creates a new idempotency Middleware with the given options.
-func New(opts ...Option) *Middleware {
+// It returns an error if the configuration is invalid
+// (e.g. empty keyHeader or non-positive ttl).
+func New(opts ...Option) (*Middleware, error) {
 	cfg := defaultConfig()
 	for _, opt := range opts {
 		opt(cfg)
+	}
+
+	if err := cfg.validate(); err != nil {
+		return nil, err
 	}
 
 	if cfg.storage == nil {
 		cfg.storage = NewMemoryStorage()
 	}
 
-	return &Middleware{cfg: cfg}
+	return &Middleware{cfg: cfg}, nil
 }
 
 type memoryEntry struct {

--- a/idem_test.go
+++ b/idem_test.go
@@ -15,7 +15,10 @@ func TestNew(t *testing.T) {
 	t.Run("applies default config when no options given", func(t *testing.T) {
 		t.Parallel()
 
-		mw := New()
+		mw, err := New()
+		if err != nil {
+			t.Fatalf("New() error = %v", err)
+		}
 
 		if mw.cfg.keyHeader != DefaultKeyHeader {
 			t.Errorf("keyHeader = %q, want %q", mw.cfg.keyHeader, DefaultKeyHeader)
@@ -34,11 +37,14 @@ func TestNew(t *testing.T) {
 		t.Parallel()
 
 		custom := &stubStorage{}
-		mw := New(
+		mw, err := New(
 			WithKeyHeader("X-Custom-Key"),
 			WithTTL(5*time.Minute),
 			WithStorage(custom),
 		)
+		if err != nil {
+			t.Fatalf("New() error = %v", err)
+		}
 
 		if mw.cfg.keyHeader != "X-Custom-Key" {
 			t.Errorf("keyHeader = %q, want %q", mw.cfg.keyHeader, "X-Custom-Key")
@@ -56,9 +62,40 @@ func TestNew(t *testing.T) {
 	t.Run("MemoryStorage implements Locker", func(t *testing.T) {
 		t.Parallel()
 
-		mw := New()
+		mw, err := New()
+		if err != nil {
+			t.Fatalf("New() error = %v", err)
+		}
+
 		if _, ok := mw.cfg.storage.(Locker); !ok {
 			t.Error("MemoryStorage does not implement Locker")
+		}
+	})
+
+	t.Run("returns error for empty keyHeader", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := New(WithKeyHeader(""))
+		if err == nil {
+			t.Fatal("New() error = nil, want error")
+		}
+	})
+
+	t.Run("returns error for zero ttl", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := New(WithTTL(0))
+		if err == nil {
+			t.Fatal("New() error = nil, want error")
+		}
+	})
+
+	t.Run("returns error for negative ttl", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := New(WithTTL(-time.Second))
+		if err == nil {
+			t.Fatal("New() error = nil, want error")
 		}
 	})
 }

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -22,7 +22,7 @@ func TestMiddleware_Handler(t *testing.T) {
 			w.WriteHeader(http.StatusOK)
 		})
 
-		mw := New()
+		mw := newTestMiddleware(t)
 		wrapped := mw.Handler()(handler)
 
 		req := httptest.NewRequest(http.MethodPost, "/", nil)
@@ -49,7 +49,7 @@ func TestMiddleware_Handler(t *testing.T) {
 			_, _ = w.Write([]byte(`{"id":1}`))
 		})
 
-		mw := New()
+		mw := newTestMiddleware(t)
 		wrapped := mw.Handler()(handler)
 
 		// First request
@@ -99,7 +99,7 @@ func TestMiddleware_Handler(t *testing.T) {
 			w.WriteHeader(http.StatusOK)
 		})
 
-		mw := New()
+		mw := newTestMiddleware(t)
 		wrapped := mw.Handler()(handler)
 
 		for _, key := range []string{"key-a", "key-b", "key-c"} {
@@ -123,7 +123,7 @@ func TestMiddleware_Handler(t *testing.T) {
 			w.WriteHeader(http.StatusOK)
 		})
 
-		mw := New(WithKeyHeader("X-Request-Id"))
+		mw := newTestMiddleware(t, WithKeyHeader("X-Request-Id"))
 		wrapped := mw.Handler()(handler)
 
 		req1 := httptest.NewRequest(http.MethodPost, "/", nil)
@@ -148,7 +148,7 @@ func TestMiddleware_Handler(t *testing.T) {
 			w.WriteHeader(http.StatusOK)
 		})
 
-		mw := New(WithTTL(time.Nanosecond))
+		mw := newTestMiddleware(t, WithTTL(time.Nanosecond))
 		wrapped := mw.Handler()(handler)
 
 		req1 := httptest.NewRequest(http.MethodPost, "/", nil)
@@ -174,7 +174,7 @@ func TestMiddleware_Handler(t *testing.T) {
 			w.WriteHeader(http.StatusOK)
 		})
 
-		mw := New(WithStorage(store))
+		mw := newTestMiddleware(t, WithStorage(store))
 		wrapped := mw.Handler()(handler)
 
 		req := httptest.NewRequest(http.MethodPost, "/", nil)
@@ -200,7 +200,7 @@ func TestMiddleware_Handler(t *testing.T) {
 		})
 
 		store := &errorStorage{getErr: errors.New("storage unavailable")}
-		mw := New(WithStorage(store))
+		mw := newTestMiddleware(t, WithStorage(store))
 		wrapped := mw.Handler()(handler)
 
 		req := httptest.NewRequest(http.MethodPost, "/", nil)
@@ -227,7 +227,7 @@ func TestMiddleware_Handler(t *testing.T) {
 		})
 
 		store := &errorStorage{getErr: getErr}
-		mw := New(WithStorage(store), WithOnError(func(err error) { gotErr = err }))
+		mw := newTestMiddleware(t, WithStorage(store), WithOnError(func(err error) { gotErr = err }))
 		wrapped := mw.Handler()(handler)
 
 		req := httptest.NewRequest(http.MethodPost, "/", nil)
@@ -249,7 +249,7 @@ func TestMiddleware_Handler(t *testing.T) {
 		})
 
 		store := &errorStorage{setErr: setErr}
-		mw := New(WithStorage(store), WithOnError(func(err error) { gotErr = err }))
+		mw := newTestMiddleware(t, WithStorage(store), WithOnError(func(err error) { gotErr = err }))
 		wrapped := mw.Handler()(handler)
 
 		req := httptest.NewRequest(http.MethodPost, "/", nil)
@@ -274,7 +274,7 @@ func TestMiddleware_Handler(t *testing.T) {
 			w.WriteHeader(http.StatusOK)
 		})
 
-		mw := New(WithStorage(store))
+		mw := newTestMiddleware(t, WithStorage(store))
 		wrapped := mw.Handler()(handler)
 
 		req := httptest.NewRequest(http.MethodPost, "/", nil)
@@ -301,7 +301,7 @@ func TestMiddleware_Handler(t *testing.T) {
 
 		lockErr := errors.New("lock failed")
 		store := &errorLockerStorage{lockErr: lockErr}
-		mw := New(WithStorage(store))
+		mw := newTestMiddleware(t, WithStorage(store))
 		wrapped := mw.Handler()(handler)
 
 		req := httptest.NewRequest(http.MethodPost, "/", nil)
@@ -328,7 +328,7 @@ func TestMiddleware_Handler(t *testing.T) {
 		})
 
 		store := &errorLockerStorage{lockErr: lockErr}
-		mw := New(WithStorage(store), WithOnError(func(err error) { gotErr = err }))
+		mw := newTestMiddleware(t, WithStorage(store), WithOnError(func(err error) { gotErr = err }))
 		wrapped := mw.Handler()(handler)
 
 		req := httptest.NewRequest(http.MethodPost, "/", nil)
@@ -355,7 +355,7 @@ func TestMiddleware_Handler(t *testing.T) {
 		})
 
 		store := NewMemoryStorage()
-		mw := New(WithStorage(store))
+		mw := newTestMiddleware(t, WithStorage(store))
 		wrapped := mw.Handler()(handler)
 
 		var wg sync.WaitGroup
@@ -383,6 +383,18 @@ func TestMiddleware_Handler(t *testing.T) {
 			t.Errorf("handler call count = %d, want 1", count)
 		}
 	})
+}
+
+// newTestMiddleware creates a Middleware with default options, failing the test on error.
+func newTestMiddleware(t *testing.T, opts ...Option) *Middleware {
+	t.Helper()
+
+	mw, err := New(opts...)
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	return mw
 }
 
 // spyStorage tracks Get/Set/Delete call counts.

--- a/option.go
+++ b/option.go
@@ -1,6 +1,9 @@
 package idem
 
-import "time"
+import (
+	"errors"
+	"time"
+)
 
 const (
 	// DefaultKeyHeader is the default HTTP header name for the idempotency key.
@@ -56,4 +59,17 @@ func WithOnError(fn func(error)) Option {
 	return func(c *config) {
 		c.onError = fn
 	}
+}
+
+// validate checks the config for invalid values.
+func (c *config) validate() error {
+	if c.keyHeader == "" {
+		return errors.New("idem: keyHeader must not be empty")
+	}
+
+	if c.ttl <= 0 {
+		return errors.New("idem: ttl must be positive")
+	}
+
+	return nil
 }

--- a/option_test.go
+++ b/option_test.go
@@ -132,3 +132,62 @@ func TestWithOnError(t *testing.T) {
 		t.Error("callback was not called")
 	}
 }
+
+func TestConfig_validate(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		cfg     *config
+		wantErr bool
+	}{
+		{
+			name:    "valid default config",
+			cfg:     defaultConfig(),
+			wantErr: false,
+		},
+		{
+			name: "valid custom config",
+			cfg: &config{
+				keyHeader: "X-Request-Id",
+				ttl:       5 * time.Minute,
+			},
+			wantErr: false,
+		},
+		{
+			name: "empty keyHeader",
+			cfg: &config{
+				keyHeader: "",
+				ttl:       DefaultTTL,
+			},
+			wantErr: true,
+		},
+		{
+			name: "zero ttl",
+			cfg: &config{
+				keyHeader: DefaultKeyHeader,
+				ttl:       0,
+			},
+			wantErr: true,
+		},
+		{
+			name: "negative ttl",
+			cfg: &config{
+				keyHeader: DefaultKeyHeader,
+				ttl:       -time.Second,
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := tt.cfg.validate()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Change `New()` signature from `*Middleware` to `(*Middleware, error)` to validate configuration
- Add `config.validate()` that rejects empty `keyHeader` and non-positive `ttl`
- Update all test files with `newTestMiddleware` helper for cleaner error handling
- Update framework examples (Chi, Echo, Gin) with error handling
- Update README.md code examples to reflect the new signature

## Test plan
- [x] `config.validate()` unit tests: valid config, empty keyHeader, zero TTL, negative TTL
- [x] `New()` unit tests: default config, custom options, validation error cases
- [x] Existing middleware tests updated and passing
- [x] `go test -short -race ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)