### PR TITLE
Close #28: Add metrics hooks for cache hit/miss/error observation

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ The first request executes the handler and caches the response. Subsequent reque
 | `WithTTL(d)` | `24h` | Cache duration for stored responses |
 | `WithStorage(s)` | In-memory | Storage backend for cached responses |
 | `WithOnError(fn)` | `nil` | Callback invoked when a storage operation fails |
+| `WithMetrics(m)` | `nil` | Callbacks for observing cache hits, misses, and errors |
 
 ```go
 mw, err := idem.New(
@@ -80,6 +81,28 @@ if err != nil {
 ```
 
 `New` validates the configuration and returns an error for invalid values such as an empty key header or a non-positive TTL.
+
+### Metrics
+
+Use `WithMetrics` to observe cache hits, misses, and errors — for example, to export to Prometheus:
+
+```go
+mw, err := idem.New(
+	idem.WithMetrics(idem.Metrics{
+		OnCacheHit: func(key string) {
+			cacheHits.WithLabelValues(key).Inc()
+		},
+		OnCacheMiss: func(key string) {
+			cacheMisses.WithLabelValues(key).Inc()
+		},
+		OnError: func(key string, err error) {
+			cacheErrors.WithLabelValues(key).Inc()
+		},
+	}),
+)
+```
+
+All callback fields are optional — nil callbacks are never invoked and add no overhead. Requests without an idempotency key bypass the middleware entirely and do not trigger any metrics callbacks.
 
 ## How It Works
 
@@ -226,4 +249,5 @@ See [`_examples/chi/main.go`](./_examples/chi/main.go) for the full source inclu
 | v0.2 | **Done** | Redis storage |
 | v0.3 | **Done** | Framework examples (Gin / Echo / Chi) |
 | v0.4 | **Done** | Concurrent request handling (lock mechanism) |
+| v0.5 | **Done** | Metrics hooks (cache hit/miss/error callbacks) |
 | v1.0 | Planned | Documentation + stable release |

--- a/metrics.go
+++ b/metrics.go
@@ -1,0 +1,23 @@
+package idem
+
+// Metrics holds callback functions for observing middleware events.
+// All fields are optional; nil callbacks are never invoked.
+type Metrics struct {
+	// OnCacheHit is called when a cached response is found for the idempotency key.
+	OnCacheHit func(key string)
+
+	// OnCacheMiss is called when no cached response exists for the idempotency key.
+	OnCacheMiss func(key string)
+
+	// OnError is called when a storage or lock operation fails.
+	OnError func(key string, err error)
+}
+
+// WithMetrics specifies callbacks for observing middleware events such as
+// cache hits, cache misses, and errors. Passing a zero-value Metrics is
+// valid and results in no overhead.
+func WithMetrics(m Metrics) Option {
+	return func(c *config) {
+		c.metrics = &m
+	}
+}

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -1,0 +1,39 @@
+package idem
+
+import "testing"
+
+func TestWithMetrics(t *testing.T) {
+	t.Parallel()
+
+	t.Run("sets metrics on config", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := defaultConfig()
+
+		called := false
+		WithMetrics(Metrics{
+			OnCacheHit: func(_ string) { called = true },
+		})(cfg)
+
+		if cfg.metrics == nil {
+			t.Fatal("metrics = nil, want non-nil")
+		}
+
+		cfg.metrics.OnCacheHit("test")
+
+		if !called {
+			t.Error("OnCacheHit callback was not called")
+		}
+	})
+
+	t.Run("sets metrics with zero-value Metrics", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := defaultConfig()
+		WithMetrics(Metrics{})(cfg)
+
+		if cfg.metrics == nil {
+			t.Error("metrics = nil, want non-nil even for zero-value Metrics")
+		}
+	})
+}

--- a/middleware.go
+++ b/middleware.go
@@ -27,6 +27,9 @@ func (m *Middleware) Handler() func(http.Handler) http.Handler {
 					if m.cfg.onError != nil {
 						m.cfg.onError(err)
 					}
+					if m.cfg.metrics != nil && m.cfg.metrics.OnError != nil {
+						m.cfg.metrics.OnError(key, err)
+					}
 					http.Error(w, http.StatusText(http.StatusConflict), http.StatusConflict)
 					return
 				}
@@ -38,13 +41,23 @@ func (m *Middleware) Handler() func(http.Handler) http.Handler {
 				if m.cfg.onError != nil {
 					m.cfg.onError(err)
 				}
+				if m.cfg.metrics != nil && m.cfg.metrics.OnError != nil {
+					m.cfg.metrics.OnError(key, err)
+				}
 				next.ServeHTTP(w, r)
 				return
 			}
 
 			if cached != nil {
+				if m.cfg.metrics != nil && m.cfg.metrics.OnCacheHit != nil {
+					m.cfg.metrics.OnCacheHit(key)
+				}
 				writeResponse(w, cached)
 				return
+			}
+
+			if m.cfg.metrics != nil && m.cfg.metrics.OnCacheMiss != nil {
+				m.cfg.metrics.OnCacheMiss(key)
 			}
 
 			rec := newResponseRecorder(w)
@@ -55,6 +68,9 @@ func (m *Middleware) Handler() func(http.Handler) http.Handler {
 			if err := m.cfg.storage.Set(r.Context(), key, res, m.cfg.ttl); err != nil {
 				if m.cfg.onError != nil {
 					m.cfg.onError(err)
+				}
+				if m.cfg.metrics != nil && m.cfg.metrics.OnError != nil {
+					m.cfg.metrics.OnError(key, err)
 				}
 			}
 

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -344,6 +344,201 @@ func TestMiddleware_Handler(t *testing.T) {
 		}
 	})
 
+	t.Run("calls OnCacheMiss on first request and OnCacheHit on second", func(t *testing.T) {
+		t.Parallel()
+
+		handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		})
+
+		var hitKey, missKey string
+		mw := newTestMiddleware(t, WithMetrics(Metrics{
+			OnCacheHit:  func(key string) { hitKey = key },
+			OnCacheMiss: func(key string) { missKey = key },
+		}))
+		wrapped := mw.Handler()(handler)
+
+		// First request — cache miss
+		req1 := httptest.NewRequest(http.MethodPost, "/", nil)
+		req1.Header.Set("Idempotency-Key", "metrics-key")
+		wrapped.ServeHTTP(httptest.NewRecorder(), req1)
+
+		if missKey != "metrics-key" {
+			t.Errorf("OnCacheMiss key = %q, want %q", missKey, "metrics-key")
+		}
+
+		if hitKey != "" {
+			t.Errorf("OnCacheHit key = %q, want empty on first request", hitKey)
+		}
+
+		// Second request — cache hit
+		req2 := httptest.NewRequest(http.MethodPost, "/", nil)
+		req2.Header.Set("Idempotency-Key", "metrics-key")
+		wrapped.ServeHTTP(httptest.NewRecorder(), req2)
+
+		if hitKey != "metrics-key" {
+			t.Errorf("OnCacheHit key = %q, want %q", hitKey, "metrics-key")
+		}
+	})
+
+	t.Run("calls Metrics.OnError when storage Get fails", func(t *testing.T) {
+		t.Parallel()
+
+		handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		})
+
+		getErr := errors.New("get failed")
+		var gotKey string
+		var gotErr error
+		store := &errorStorage{getErr: getErr}
+		mw := newTestMiddleware(t, WithStorage(store), WithMetrics(Metrics{
+			OnError: func(key string, err error) {
+				gotKey = key
+				gotErr = err
+			},
+		}))
+		wrapped := mw.Handler()(handler)
+
+		req := httptest.NewRequest(http.MethodPost, "/", nil)
+		req.Header.Set("Idempotency-Key", "err-get-key")
+		wrapped.ServeHTTP(httptest.NewRecorder(), req)
+
+		if gotKey != "err-get-key" {
+			t.Errorf("OnError key = %q, want %q", gotKey, "err-get-key")
+		}
+
+		if !errors.Is(gotErr, getErr) {
+			t.Errorf("OnError err = %v, want %v", gotErr, getErr)
+		}
+	})
+
+	t.Run("calls Metrics.OnError when storage Set fails", func(t *testing.T) {
+		t.Parallel()
+
+		handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		})
+
+		setErr := errors.New("set failed")
+		var gotKey string
+		var gotErr error
+		store := &errorStorage{setErr: setErr}
+		mw := newTestMiddleware(t, WithStorage(store), WithMetrics(Metrics{
+			OnError: func(key string, err error) {
+				gotKey = key
+				gotErr = err
+			},
+		}))
+		wrapped := mw.Handler()(handler)
+
+		req := httptest.NewRequest(http.MethodPost, "/", nil)
+		req.Header.Set("Idempotency-Key", "err-set-key")
+		wrapped.ServeHTTP(httptest.NewRecorder(), req)
+
+		if gotKey != "err-set-key" {
+			t.Errorf("OnError key = %q, want %q", gotKey, "err-set-key")
+		}
+
+		if !errors.Is(gotErr, setErr) {
+			t.Errorf("OnError err = %v, want %v", gotErr, setErr)
+		}
+	})
+
+	t.Run("calls Metrics.OnError when lock acquisition fails", func(t *testing.T) {
+		t.Parallel()
+
+		handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		})
+
+		lockErr := errors.New("lock failed")
+		var gotKey string
+		var gotErr error
+		store := &errorLockerStorage{lockErr: lockErr}
+		mw := newTestMiddleware(t, WithStorage(store), WithMetrics(Metrics{
+			OnError: func(key string, err error) {
+				gotKey = key
+				gotErr = err
+			},
+		}))
+		wrapped := mw.Handler()(handler)
+
+		req := httptest.NewRequest(http.MethodPost, "/", nil)
+		req.Header.Set("Idempotency-Key", "err-lock-key")
+		wrapped.ServeHTTP(httptest.NewRecorder(), req)
+
+		if gotKey != "err-lock-key" {
+			t.Errorf("OnError key = %q, want %q", gotKey, "err-lock-key")
+		}
+
+		if !errors.Is(gotErr, lockErr) {
+			t.Errorf("OnError err = %v, want %v", gotErr, lockErr)
+		}
+	})
+
+	t.Run("calls both WithOnError and Metrics.OnError on storage Get failure", func(t *testing.T) {
+		t.Parallel()
+
+		handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		})
+
+		getErr := errors.New("get failed")
+		var onErrorCalled bool
+		var metricsErrorCalled bool
+		store := &errorStorage{getErr: getErr}
+		mw := newTestMiddleware(t,
+			WithStorage(store),
+			WithOnError(func(_ error) { onErrorCalled = true }),
+			WithMetrics(Metrics{
+				OnError: func(_ string, _ error) { metricsErrorCalled = true },
+			}),
+		)
+		wrapped := mw.Handler()(handler)
+
+		req := httptest.NewRequest(http.MethodPost, "/", nil)
+		req.Header.Set("Idempotency-Key", "both-err-key")
+		wrapped.ServeHTTP(httptest.NewRecorder(), req)
+
+		if !onErrorCalled {
+			t.Error("WithOnError callback was not called")
+		}
+
+		if !metricsErrorCalled {
+			t.Error("Metrics.OnError callback was not called")
+		}
+	})
+
+	t.Run("does not panic with nil callback fields in Metrics", func(t *testing.T) {
+		t.Parallel()
+
+		handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		})
+
+		// Only OnCacheMiss is set; OnCacheHit and OnError are nil
+		var missKey string
+		mw := newTestMiddleware(t, WithMetrics(Metrics{
+			OnCacheMiss: func(key string) { missKey = key },
+		}))
+		wrapped := mw.Handler()(handler)
+
+		// First request — triggers OnCacheMiss, skips nil OnCacheHit/OnError
+		req1 := httptest.NewRequest(http.MethodPost, "/", nil)
+		req1.Header.Set("Idempotency-Key", "partial-key")
+		wrapped.ServeHTTP(httptest.NewRecorder(), req1)
+
+		if missKey != "partial-key" {
+			t.Errorf("OnCacheMiss key = %q, want %q", missKey, "partial-key")
+		}
+
+		// Second request — triggers nil OnCacheHit without panic
+		req2 := httptest.NewRequest(http.MethodPost, "/", nil)
+		req2.Header.Set("Idempotency-Key", "partial-key")
+		wrapped.ServeHTTP(httptest.NewRecorder(), req2)
+	})
+
 	t.Run("concurrent requests with same key execute handler only once", func(t *testing.T) {
 		t.Parallel()
 

--- a/option.go
+++ b/option.go
@@ -18,6 +18,7 @@ type config struct {
 	ttl       time.Duration
 	storage   Storage
 	onError   func(error)
+	metrics   *Metrics
 }
 
 // defaultConfig returns a config with sensible defaults.


### PR DESCRIPTION
## Summary
- Add `Metrics` struct with `OnCacheHit`, `OnCacheMiss`, and `OnError` callback fields
- Add `WithMetrics(Metrics)` option function following the existing functional options pattern
- Invoke metrics callbacks at each event point in the middleware handler (cache hit, cache miss, lock/get/set errors)
- Both `WithOnError` and `Metrics.OnError` are called when both are configured
- Nil callbacks are never invoked, adding no overhead when metrics are not configured
- Update README with metrics documentation and Prometheus usage example

## Test plan
- [x] `WithMetrics` sets `config.metrics` correctly
- [x] Zero-value `Metrics` results in non-nil `metrics` field
- [x] `OnCacheMiss` called on first request, `OnCacheHit` called on second
- [x] `Metrics.OnError` called with key and error on `Storage.Get` failure
- [x] `Metrics.OnError` called with key and error on `Storage.Set` failure
- [x] `Metrics.OnError` called with key and error on lock acquisition failure
- [x] Both `WithOnError` and `Metrics.OnError` called together
- [x] No panic with nil callback fields in `Metrics`
- [x] All tests pass with `-race` flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)