### PR TITLE
Add workflow to close milestone on release publish

### DIFF
--- a/.github/workflows/on-release-published.yml
+++ b/.github/workflows/on-release-published.yml
@@ -1,0 +1,32 @@
+name: on-release-published
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  issues: write
+
+jobs:
+  close-milestone:
+    name: Close Milestone
+    runs-on: ubuntu-latest
+    steps:
+      - name: Close milestone matching release tag
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          TAG: ${{ github.event.release.tag_name }}
+        run: |
+          MILESTONE_NUMBER=$(gh api "repos/$REPO/milestones?state=open" \
+            --jq ".[] | select(.title == \"$TAG\") | .number")
+
+          if [ -z "$MILESTONE_NUMBER" ]; then
+            echo "No open milestone found for tag '$TAG'. Skipping."
+            exit 0
+          fi
+
+          gh api -X PATCH "repos/$REPO/milestones/$MILESTONE_NUMBER" \
+            -f state=closed
+
+          echo "Closed milestone '$TAG' (#$MILESTONE_NUMBER)."


### PR DESCRIPTION
## Summary
- Release が publish されたとき、タグ名と一致するマイルストーンを自動でクローズする GitHub Actions ワークフローを追加
- マイルストーンが見つからない場合はスキップする

## Test plan
- [ ] マイルストーン名とタグ名が一致するリリースを作成し、マイルストーンがクローズされることを確認
- [ ] 対応するマイルストーンが存在しないリリースを作成し、エラーなくスキップされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)