### PR TITLE
Close #66: Prevent nil pointer panic on redis.New(nil)

### DIFF
--- a/redis/redis.go
+++ b/redis/redis.go
@@ -74,6 +74,10 @@ func New(client goredis.Cmdable, opts ...Option) (*Storage, error) {
 
 // validate checks the Storage configuration for invalid values.
 func (s *Storage) validate() error {
+	if s.client == nil {
+		return errors.New("redis: client must not be nil")
+	}
+
 	if s.keyPrefix == "" {
 		return errors.New("redis: keyPrefix must not be empty")
 	}

--- a/redis/redis_test.go
+++ b/redis/redis_test.go
@@ -47,10 +47,22 @@ func newTestStorage(t *testing.T, client goredis.Cmdable, opts ...iredis.Option)
 func TestNew(t *testing.T) {
 	t.Parallel()
 
-	t.Run("accepts default config", func(t *testing.T) {
+	// stub client for validation-only tests (no actual Redis connection needed)
+	stub := goredis.NewClient(&goredis.Options{})
+
+	t.Run("returns error for nil client", func(t *testing.T) {
 		t.Parallel()
 
 		_, err := iredis.New(nil)
+		if err == nil {
+			t.Fatal("New(nil) error = nil, want error")
+		}
+	})
+
+	t.Run("accepts default config", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := iredis.New(stub)
 		if err != nil {
 			t.Fatalf("New() error = %v", err)
 		}
@@ -59,7 +71,7 @@ func TestNew(t *testing.T) {
 	t.Run("accepts valid custom prefixes", func(t *testing.T) {
 		t.Parallel()
 
-		_, err := iredis.New(nil, iredis.WithKeyPrefix("custom:"), iredis.WithLockPrefix("custom:lock:"))
+		_, err := iredis.New(stub, iredis.WithKeyPrefix("custom:"), iredis.WithLockPrefix("custom:lock:"))
 		if err != nil {
 			t.Fatalf("New() error = %v", err)
 		}
@@ -68,7 +80,7 @@ func TestNew(t *testing.T) {
 	t.Run("returns error for empty keyPrefix", func(t *testing.T) {
 		t.Parallel()
 
-		_, err := iredis.New(nil, iredis.WithKeyPrefix(""))
+		_, err := iredis.New(stub, iredis.WithKeyPrefix(""))
 		if err == nil {
 			t.Fatal("New() error = nil, want error")
 		}
@@ -77,7 +89,7 @@ func TestNew(t *testing.T) {
 	t.Run("returns error for empty lockPrefix", func(t *testing.T) {
 		t.Parallel()
 
-		_, err := iredis.New(nil, iredis.WithLockPrefix(""))
+		_, err := iredis.New(stub, iredis.WithLockPrefix(""))
 		if err == nil {
 			t.Fatal("New() error = nil, want error")
 		}


### PR DESCRIPTION
## Summary
- Add `client == nil` check as the first validation in `validate()`, returning `errors.New("redis: client must not be nil")` before any other checks
- Update `TestNew` to use a stub `goredis.NewClient` instead of `nil` for prefix validation tests, and add a dedicated `"returns error for nil client"` test case

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test -short -race ./...` passes
- [x] Integration tests pass in CI (existing tests unaffected — they use real Redis clients)

🤖 Generated with [Claude Code](https://claude.com/claude-code)