### PR TITLE
Close #67: Add OnLockContention metrics hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ if err != nil {
 
 ### Metrics
 
-Use `WithMetrics` to observe cache hits, misses, and errors — for example, to export to Prometheus:
+Use `WithMetrics` to observe cache hits, misses, lock contention, and errors — for example, to export to Prometheus:
 
 ```go
 mw, err := idem.New(
@@ -95,6 +95,9 @@ mw, err := idem.New(
 		OnCacheMiss: func(key string) {
 			cacheMisses.WithLabelValues(key).Inc()
 		},
+		OnLockContention: func(key string, err error) {
+			lockContentions.WithLabelValues(key).Inc()
+		},
 		OnError: func(key string, err error) {
 			cacheErrors.WithLabelValues(key).Inc()
 		},
@@ -102,7 +105,7 @@ mw, err := idem.New(
 )
 ```
 
-All callback fields are optional — nil callbacks are never invoked and add no overhead. Requests without an idempotency key bypass the middleware entirely and do not trigger any metrics callbacks.
+All callback fields are optional — nil callbacks are never invoked and add no overhead. Lock contention (409 Conflict) is reported exclusively via `OnLockContention` and does not trigger `OnError`. Requests without an idempotency key bypass the middleware entirely and do not trigger any metrics callbacks.
 
 ## How It Works
 

--- a/metrics.go
+++ b/metrics.go
@@ -9,7 +9,13 @@ type Metrics struct {
 	// OnCacheMiss is called when no cached response exists for the idempotency key.
 	OnCacheMiss func(key string)
 
-	// OnError is called when a storage or lock operation fails.
+	// OnLockContention is called when lock acquisition fails for the idempotency key,
+	// resulting in a 409 Conflict response. When this event fires, OnError is not called;
+	// lock contention is treated as a normal concurrency-control signal, not an error.
+	OnLockContention func(key string, err error)
+
+	// OnError is called when a storage operation (Get, Set, or Delete) fails.
+	// Lock contention is reported via OnLockContention instead.
 	OnError func(key string, err error)
 }
 

--- a/middleware.go
+++ b/middleware.go
@@ -27,8 +27,8 @@ func (m *Middleware) Handler() func(http.Handler) http.Handler {
 					if m.cfg.onError != nil {
 						m.cfg.onError(err)
 					}
-					if m.cfg.metrics != nil && m.cfg.metrics.OnError != nil {
-						m.cfg.metrics.OnError(key, err)
+					if m.cfg.metrics != nil && m.cfg.metrics.OnLockContention != nil {
+						m.cfg.metrics.OnLockContention(key, err)
 					}
 					http.Error(w, http.StatusText(http.StatusConflict), http.StatusConflict)
 					return

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -445,7 +445,7 @@ func TestMiddleware_Handler(t *testing.T) {
 		}
 	})
 
-	t.Run("calls Metrics.OnError when lock acquisition fails", func(t *testing.T) {
+	t.Run("calls Metrics.OnLockContention when lock acquisition fails", func(t *testing.T) {
 		t.Parallel()
 
 		handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -457,7 +457,7 @@ func TestMiddleware_Handler(t *testing.T) {
 		var gotErr error
 		store := &errorLockerStorage{lockErr: lockErr}
 		mw := newTestMiddleware(t, WithStorage(store), WithMetrics(Metrics{
-			OnError: func(key string, err error) {
+			OnLockContention: func(key string, err error) {
 				gotKey = key
 				gotErr = err
 			},
@@ -469,11 +469,58 @@ func TestMiddleware_Handler(t *testing.T) {
 		wrapped.ServeHTTP(httptest.NewRecorder(), req)
 
 		if gotKey != "err-lock-key" {
-			t.Errorf("OnError key = %q, want %q", gotKey, "err-lock-key")
+			t.Errorf("OnLockContention key = %q, want %q", gotKey, "err-lock-key")
 		}
 
 		if !errors.Is(gotErr, lockErr) {
-			t.Errorf("OnError err = %v, want %v", gotErr, lockErr)
+			t.Errorf("OnLockContention err = %v, want %v", gotErr, lockErr)
+		}
+	})
+
+	t.Run("does not call Metrics.OnError when lock acquisition fails", func(t *testing.T) {
+		t.Parallel()
+
+		handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		})
+
+		lockErr := errors.New("lock failed")
+		var onErrorCalled bool
+		store := &errorLockerStorage{lockErr: lockErr}
+		mw := newTestMiddleware(t, WithStorage(store), WithMetrics(Metrics{
+			OnError: func(_ string, _ error) { onErrorCalled = true },
+		}))
+		wrapped := mw.Handler()(handler)
+
+		req := httptest.NewRequest(http.MethodPost, "/", nil)
+		req.Header.Set("Idempotency-Key", "err-lock-key")
+		wrapped.ServeHTTP(httptest.NewRecorder(), req)
+
+		if onErrorCalled {
+			t.Error("Metrics.OnError was called on lock contention, want not called")
+		}
+	})
+
+	t.Run("does not call Metrics.OnLockContention on storage errors", func(t *testing.T) {
+		t.Parallel()
+
+		handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		})
+
+		var onLockContentionCalled bool
+		store := &errorStorage{getErr: errors.New("get failed")}
+		mw := newTestMiddleware(t, WithStorage(store), WithMetrics(Metrics{
+			OnLockContention: func(_ string, _ error) { onLockContentionCalled = true },
+		}))
+		wrapped := mw.Handler()(handler)
+
+		req := httptest.NewRequest(http.MethodPost, "/", nil)
+		req.Header.Set("Idempotency-Key", "storage-err-key")
+		wrapped.ServeHTTP(httptest.NewRecorder(), req)
+
+		if onLockContentionCalled {
+			t.Error("Metrics.OnLockContention was called on storage error, want not called")
 		}
 	})
 


### PR DESCRIPTION
## Summary
- Add `OnLockContention` callback field to `Metrics` struct for observing lock contention (409 Conflict) events separately from storage errors
- Replace `Metrics.OnError` with `Metrics.OnLockContention` in the lock failure path of the middleware
- Add tests verifying `OnLockContention` is called on lock failure, `OnError` is not called on lock contention, and `OnLockContention` is not called on storage errors
- Update README metrics example to include `OnLockContention`

## Test plan
- [x] `OnLockContention` called with correct key and error on lock failure
- [x] `Metrics.OnError` not called when lock acquisition fails
- [x] `OnLockContention` not called on storage Get/Set errors
- [x] All existing tests pass (`go test ./... -short`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)