### PR TITLE
Close #71: Add Redis Sentinel integration test

### DIFF
--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -97,6 +97,51 @@ jobs:
             127.0.0.1:7000 127.0.0.1:7001 127.0.0.1:7002 \
             --cluster-replicas 0 --cluster-yes
 
+      - name: Start Redis Sentinel
+        run: |
+          # Start master
+          docker run -d --name redis-sentinel-master --network host \
+            redis:8-alpine redis-server --port 6380 --bind 0.0.0.0
+
+          # Start replica
+          docker run -d --name redis-sentinel-replica --network host \
+            redis:8-alpine redis-server --port 6381 --bind 0.0.0.0 \
+            --replicaof 127.0.0.1 6380
+
+          # Wait for master and replica
+          for port in 6380 6381; do
+            for i in $(seq 1 30); do
+              if docker exec redis-sentinel-master redis-cli -p $port ping 2>/dev/null | grep -q PONG; then
+                break
+              fi
+              sleep 1
+            done
+          done
+
+          # Start 3 sentinels
+          for port in 26379 26380 26381; do
+            docker run -d --name redis-sentinel-$port --network host \
+              redis:8-alpine sh -c "
+                cat <<CONF > /tmp/sentinel.conf
+          port $port
+          sentinel monitor mymaster 127.0.0.1 6380 2
+          sentinel down-after-milliseconds mymaster 5000
+          sentinel failover-timeout mymaster 10000
+          sentinel parallel-syncs mymaster 1
+          CONF
+                redis-server /tmp/sentinel.conf --sentinel"
+          done
+
+          # Wait for sentinels to discover master
+          for i in $(seq 1 30); do
+            MASTER=$(docker exec redis-sentinel-26379 redis-cli -p 26379 SENTINEL get-master-addr-by-name mymaster 2>/dev/null | head -1)
+            if [ -n "$MASTER" ]; then
+              echo "Sentinel ready: master=$MASTER"
+              break
+            fi
+            sleep 1
+          done
+
       - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
@@ -107,6 +152,8 @@ jobs:
       - name: Run integration tests
         env:
           REDIS_CLUSTER_ADDRS: "localhost:7000,localhost:7001,localhost:7002"
+          REDIS_SENTINEL_ADDRS: "localhost:26379,localhost:26380,localhost:26381"
+          REDIS_SENTINEL_MASTER: "mymaster"
         run: |
           gotestsum \
             --junitfile integration-test-report.xml \

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ Module: `github.com/bright-room/idem` | Go 1.25.5 | Pre-v1.0
 
 ## Development Commands
 
-All commands run inside Docker (via `compose.yml`). Use `make build` first to build the image. The `compose.yml` includes standalone Redis and a 3-node Redis Cluster (ports 7000-7002) for integration tests.
+All commands run inside Docker (via `compose.yml`). Use `make build` first to build the image. The `compose.yml` includes standalone Redis, a 3-node Redis Cluster (ports 7000-7002), and a Redis Sentinel setup (master + replica + 3 sentinels on ports 26379-26381) for integration tests.
 
 ```bash
 make build          # Build Docker image
@@ -39,7 +39,7 @@ Configuration uses the **Functional Options** pattern (`WithXxx()` functions).
 ## Conventions
 
 - **Linting**: golangci-lint v2.10.1 with gofumpt formatting. Zero tolerance (no issue limits). See `.golangci.yml` for enabled linters.
-- **Testing**: Table-driven tests, `gotestsum` with testdox output, `-race` flag. Integration tests use `Integration` prefix in test names. Redis Cluster tests require `REDIS_CLUSTER_ADDRS` env var (comma-separated addresses); skipped when unset.
+- **Testing**: Table-driven tests, `gotestsum` with testdox output, `-race` flag. Integration tests use `Integration` prefix in test names. Redis Cluster tests require `REDIS_CLUSTER_ADDRS` env var (comma-separated addresses); skipped when unset. Redis Sentinel tests require `REDIS_SENTINEL_ADDRS` (comma-separated sentinel addresses) and optionally `REDIS_SENTINEL_MASTER` (defaults to `mymaster`); skipped when unset.
 - **Naming**: Short receiver names (`s`, `m`). Interface names use "-er" suffix.
 - **Git branching**: `feat/issue-number-description` or `fix/issue-number-description`. PR titles prefixed with `Close #IssueNumber`.
 

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ mw, err := idem.New() // uses in-memory storage
 
 ### Redis
 
-For multi-instance deployments where idempotency state must be shared across processes.
+For multi-instance deployments where idempotency state must be shared across processes. The `idem/redis` package accepts `goredis.Cmdable`, so it works with standalone, cluster, and sentinel (failover) clients.
 
 ```go
 import (
@@ -174,7 +174,20 @@ import (
 	goredis "github.com/redis/go-redis/v9"
 )
 
+// Standalone
 client := goredis.NewClient(&goredis.Options{Addr: "localhost:6379"})
+
+// Cluster
+// client := goredis.NewClusterClient(&goredis.ClusterOptions{
+// 	Addrs: []string{"localhost:7000", "localhost:7001", "localhost:7002"},
+// })
+
+// Sentinel (Failover)
+// client := goredis.NewFailoverClient(&goredis.FailoverOptions{
+// 	MasterName:    "mymaster",
+// 	SentinelAddrs: []string{"localhost:26379", "localhost:26380", "localhost:26381"},
+// })
+
 store, err := idemredis.New(client)
 if err != nil {
 	log.Fatal(err)
@@ -304,6 +317,21 @@ curl -X POST http://localhost:8082/orders -H "Idempotency-Key: key-123"
 The `idem/redis` package accepts `goredis.Cmdable`, so switching from `*redis.Client` to `*redis.ClusterClient` requires no code changes.
 
 See [`_examples/redis-cluster-gin/`](./_examples/redis-cluster-gin/) for the full setup.
+
+### Redis Sentinel (Failover)
+
+The `idem/redis` package also works with Redis Sentinel via `goredis.NewFailoverClient`:
+
+```go
+client := goredis.NewFailoverClient(&goredis.FailoverOptions{
+	MasterName:    "mymaster",
+	SentinelAddrs: []string{"localhost:26379", "localhost:26380", "localhost:26381"},
+})
+
+store, err := idemredis.New(client)
+```
+
+See [`_examples/redis-sentinel-gin/main.go`](./_examples/redis-sentinel-gin/main.go) for a full Gin example.
 
 ### Docker Compose (Prometheus Metrics)
 

--- a/_examples/redis-sentinel-gin/main.go
+++ b/_examples/redis-sentinel-gin/main.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"strings"
+	"sync/atomic"
+
+	"github.com/bright-room/idem"
+	idemredis "github.com/bright-room/idem/redis"
+	"github.com/gin-gonic/gin"
+	goredis "github.com/redis/go-redis/v9"
+)
+
+func main() {
+	sentinelAddrs := os.Getenv("REDIS_SENTINEL_ADDRS")
+	if sentinelAddrs == "" {
+		sentinelAddrs = "localhost:26379,localhost:26380,localhost:26381"
+	}
+
+	masterName := os.Getenv("REDIS_SENTINEL_MASTER")
+	if masterName == "" {
+		masterName = "mymaster"
+	}
+
+	instanceID := os.Getenv("HOSTNAME")
+	if instanceID == "" {
+		instanceID = "unknown"
+	}
+
+	client := goredis.NewFailoverClient(&goredis.FailoverOptions{
+		MasterName:    masterName,
+		SentinelAddrs: strings.Split(sentinelAddrs, ","),
+	})
+
+	store, err := idemredis.New(client)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	idempotency, err := idem.New(
+		idem.WithStorage(store),
+		idem.WithOnError(func(err error) {
+			log.Printf("[idem] error: %v", err)
+		}),
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+	wrap := wrapMiddleware(idempotency)
+
+	r := gin.Default()
+
+	var orderCount atomic.Int64
+
+	r.POST("/orders", wrap, func(c *gin.Context) {
+		n := orderCount.Add(1)
+		c.JSON(http.StatusCreated, gin.H{
+			"order_id":    fmt.Sprintf("order-%d", n),
+			"message":     "order created",
+			"instance_id": instanceID,
+		})
+	})
+
+	r.GET("/health", func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{
+			"status":      "ok",
+			"instance_id": instanceID,
+		})
+	})
+
+	log.Printf("starting server on :8080 (instance: %s)", instanceID)
+	r.Run(":8080")
+}
+
+// wrapMiddleware converts idem.Middleware into a gin.HandlerFunc.
+func wrapMiddleware(m *idem.Middleware) gin.HandlerFunc {
+	handler := m.Handler()
+	return func(c *gin.Context) {
+		handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			c.Request = r
+			c.Next()
+		})).ServeHTTP(c.Writer, c.Request)
+	}
+}

--- a/compose.yml
+++ b/compose.yml
@@ -9,9 +9,12 @@ services:
     depends_on:
       - redis
       - redis-cluster-init
+      - redis-sentinel-init
     environment:
       REDIS_ADDR: redis:6379
       REDIS_CLUSTER_ADDRS: "redis-cluster-node-1:7000,redis-cluster-node-2:7001,redis-cluster-node-3:7002"
+      REDIS_SENTINEL_ADDRS: "redis-sentinel-1:26379,redis-sentinel-2:26380,redis-sentinel-3:26381"
+      REDIS_SENTINEL_MASTER: "mymaster"
 
   redis:
     image: redis:8-alpine
@@ -65,6 +68,96 @@ services:
           redis-cluster-node-2:7001 \
           redis-cluster-node-3:7002 \
           --cluster-replicas 0 --cluster-yes
+
+  redis-sentinel-master:
+    image: redis:8-alpine
+    command: >
+      redis-server
+      --port 6380
+      --bind 0.0.0.0
+
+  redis-sentinel-replica:
+    image: redis:8-alpine
+    command: >
+      redis-server
+      --port 6381
+      --bind 0.0.0.0
+      --replicaof redis-sentinel-master 6380
+    depends_on:
+      - redis-sentinel-master
+
+  redis-sentinel-1:
+    image: redis:8-alpine
+    depends_on:
+      - redis-sentinel-master
+      - redis-sentinel-replica
+    entrypoint: ["/bin/sh", "-c"]
+    command:
+      - |
+        cat <<EOF > /tmp/sentinel.conf
+        port 26379
+        sentinel monitor mymaster redis-sentinel-master 6380 2
+        sentinel down-after-milliseconds mymaster 5000
+        sentinel failover-timeout mymaster 10000
+        sentinel parallel-syncs mymaster 1
+        EOF
+        redis-server /tmp/sentinel.conf --sentinel
+
+  redis-sentinel-2:
+    image: redis:8-alpine
+    depends_on:
+      - redis-sentinel-master
+      - redis-sentinel-replica
+    entrypoint: ["/bin/sh", "-c"]
+    command:
+      - |
+        cat <<EOF > /tmp/sentinel.conf
+        port 26380
+        sentinel monitor mymaster redis-sentinel-master 6380 2
+        sentinel down-after-milliseconds mymaster 5000
+        sentinel failover-timeout mymaster 10000
+        sentinel parallel-syncs mymaster 1
+        EOF
+        redis-server /tmp/sentinel.conf --sentinel
+
+  redis-sentinel-3:
+    image: redis:8-alpine
+    depends_on:
+      - redis-sentinel-master
+      - redis-sentinel-replica
+    entrypoint: ["/bin/sh", "-c"]
+    command:
+      - |
+        cat <<EOF > /tmp/sentinel.conf
+        port 26381
+        sentinel monitor mymaster redis-sentinel-master 6380 2
+        sentinel down-after-milliseconds mymaster 5000
+        sentinel failover-timeout mymaster 10000
+        sentinel parallel-syncs mymaster 1
+        EOF
+        redis-server /tmp/sentinel.conf --sentinel
+
+  redis-sentinel-init:
+    image: redis:8-alpine
+    depends_on:
+      - redis-sentinel-1
+      - redis-sentinel-2
+      - redis-sentinel-3
+    restart: "no"
+    entrypoint: ["/bin/sh", "-c"]
+    command:
+      - |
+        sleep 3
+        for i in $(seq 1 30); do
+          MASTER=$(redis-cli -h redis-sentinel-1 -p 26379 SENTINEL get-master-addr-by-name mymaster 2>/dev/null)
+          if [ -n "$MASTER" ]; then
+            echo "Sentinel ready: master=$MASTER"
+            exit 0
+          fi
+          sleep 1
+        done
+        echo "Sentinel init timeout"
+        exit 1
 
 volumes:
   go-mod-cache:

--- a/redis/redis_test.go
+++ b/redis/redis_test.go
@@ -53,6 +53,32 @@ func newTestClusterClient(t *testing.T) goredis.Cmdable {
 	return client
 }
 
+func newTestSentinelClient(t *testing.T) goredis.Cmdable {
+	t.Helper()
+
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	addrs := os.Getenv("REDIS_SENTINEL_ADDRS")
+	if addrs == "" {
+		t.Skip("REDIS_SENTINEL_ADDRS not set, skipping sentinel test")
+	}
+
+	masterName := os.Getenv("REDIS_SENTINEL_MASTER")
+	if masterName == "" {
+		masterName = "mymaster"
+	}
+
+	client := goredis.NewFailoverClient(&goredis.FailoverOptions{
+		MasterName:    masterName,
+		SentinelAddrs: strings.Split(addrs, ","),
+	})
+	t.Cleanup(func() { _ = client.Close() })
+
+	return client
+}
+
 func newTestStorage(t *testing.T, client goredis.Cmdable, opts ...iredis.Option) *iredis.Storage {
 	t.Helper()
 
@@ -365,6 +391,10 @@ func TestIntegration_Storage(t *testing.T) {
 
 func TestIntegration_ClusterStorage(t *testing.T) {
 	runStorageTests(t, "ClusterStorage", newTestClusterClient)
+}
+
+func TestIntegration_SentinelStorage(t *testing.T) {
+	runStorageTests(t, "SentinelStorage", newTestSentinelClient)
 }
 
 // --- Standalone-only integration tests ---


### PR DESCRIPTION
## Summary
- Add Redis Sentinel infrastructure (master + replica + 3 sentinels) to `compose.yml`
- Add `newTestSentinelClient` factory and `TestIntegration_SentinelStorage` using the shared `runStorageTests` base
- Add Sentinel setup step and env vars to CI `integration-test` job
- Add `_examples/redis-sentinel-gin/` example application
- Update README with Sentinel connection examples and CLAUDE.md with Sentinel env var docs

## Test plan
- [ ] `TestIntegration_SentinelStorage` passes all 9 shared storage/locker tests against Sentinel
- [ ] CI `integration-test` job starts Sentinel infrastructure and runs Sentinel tests
- [ ] Existing standalone and cluster integration tests remain unaffected
- [ ] `go build ./...` and `go vet ./...` pass cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)