### PR TITLE
Close #82: Add Config snapshot utilization

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,28 @@ mw, err := idem.New(
 
 All callback fields are optional — nil callbacks are never invoked and add no overhead. Lock contention (409 Conflict) is reported exclusively via `OnLockContention` and does not trigger `OnError`. Requests without an idempotency key bypass the middleware entirely and do not trigger any metrics callbacks.
 
+### Configuration Inspection
+
+Use `Middleware.Config()` to retrieve a read-only snapshot of the current configuration. This is useful for debug logging and configuration inspection endpoints.
+
+```go
+mw, _ := idem.New(
+	idem.WithTTL(1 * time.Hour),
+	idem.WithStorage(redisStore),
+)
+
+// Debug logging
+log.Printf("idem config: %s", mw.Config())
+
+// JSON endpoint
+http.HandleFunc("/debug/idem/config", func(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(mw.Config())
+})
+```
+
+The `Config` struct includes JSON tags and implements `fmt.Stringer` for convenient serialization.
+
 ## How It Works
 
 ```

--- a/middleware.go
+++ b/middleware.go
@@ -11,6 +11,13 @@ type Middleware struct {
 	cfg *config
 }
 
+// Config returns a read-only snapshot of the middleware configuration.
+// This is useful for debug logging, health check endpoints, and
+// configuration inspection.
+func (m *Middleware) Config() Config {
+	return m.cfg.snapshot()
+}
+
 // Handler returns a net/http compatible middleware handler.
 func (m *Middleware) Handler() func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -631,6 +631,86 @@ func TestMiddleware_Handler(t *testing.T) {
 	})
 }
 
+func TestMiddleware_Config(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns defaults with no options", func(t *testing.T) {
+		t.Parallel()
+
+		mw := newTestMiddleware(t)
+		cfg := mw.Config()
+
+		if cfg.KeyHeader != DefaultKeyHeader {
+			t.Errorf("KeyHeader = %q, want %q", cfg.KeyHeader, DefaultKeyHeader)
+		}
+		if cfg.TTL != DefaultTTL {
+			t.Errorf("TTL = %v, want %v", cfg.TTL, DefaultTTL)
+		}
+		if cfg.StorageType != "*idem.MemoryStorage" {
+			t.Errorf("StorageType = %q, want %q", cfg.StorageType, "*idem.MemoryStorage")
+		}
+		if !cfg.LockSupported {
+			t.Error("LockSupported = false, want true")
+		}
+		if cfg.MetricsEnabled {
+			t.Error("MetricsEnabled = true, want false")
+		}
+		if cfg.OnErrorEnabled {
+			t.Error("OnErrorEnabled = true, want false")
+		}
+		if cfg.ValidatorCount != 0 {
+			t.Errorf("ValidatorCount = %d, want 0", cfg.ValidatorCount)
+		}
+	})
+
+	t.Run("reflects custom options", func(t *testing.T) {
+		t.Parallel()
+
+		mw := newTestMiddleware(t,
+			WithKeyHeader("X-Request-Id"),
+			WithTTL(5*time.Minute),
+			WithStorage(&stubStorage{}),
+			WithOnError(func(_ error) {}),
+			WithMetrics(Metrics{}),
+			WithValidation(func(_ Config) error { return nil }),
+		)
+		cfg := mw.Config()
+
+		if cfg.KeyHeader != "X-Request-Id" {
+			t.Errorf("KeyHeader = %q, want %q", cfg.KeyHeader, "X-Request-Id")
+		}
+		if cfg.TTL != 5*time.Minute {
+			t.Errorf("TTL = %v, want %v", cfg.TTL, 5*time.Minute)
+		}
+		if cfg.StorageType != "*idem.stubStorage" {
+			t.Errorf("StorageType = %q, want %q", cfg.StorageType, "*idem.stubStorage")
+		}
+		if cfg.LockSupported {
+			t.Error("LockSupported = true, want false")
+		}
+		if !cfg.MetricsEnabled {
+			t.Error("MetricsEnabled = false, want true")
+		}
+		if !cfg.OnErrorEnabled {
+			t.Error("OnErrorEnabled = false, want true")
+		}
+		if cfg.ValidatorCount != 1 {
+			t.Errorf("ValidatorCount = %d, want 1", cfg.ValidatorCount)
+		}
+	})
+
+	t.Run("LockSupported reflects Locker implementation", func(t *testing.T) {
+		t.Parallel()
+
+		mw := newTestMiddleware(t, WithStorage(&spyLockerStorage{}))
+		cfg := mw.Config()
+
+		if !cfg.LockSupported {
+			t.Error("LockSupported = false, want true for Locker-implementing storage")
+		}
+	})
+}
+
 func TestNewResponseRecorder(t *testing.T) {
 	t.Parallel()
 

--- a/option.go
+++ b/option.go
@@ -2,6 +2,7 @@ package idem
 
 import (
 	"errors"
+	"fmt"
 	"time"
 )
 
@@ -16,12 +17,30 @@ const (
 // Config is a read-only snapshot of the middleware configuration.
 // It is passed to Validator functions so they can inspect—but not modify—the
 // settings that will be used by the middleware.
+//
+// Config is also available via Middleware.Config() for debug logging
+// and configuration inspection endpoints.
 type Config struct {
 	// KeyHeader is the HTTP header name used to retrieve the idempotency key.
-	KeyHeader string
+	KeyHeader string `json:"key_header"`
 
 	// TTL is the time-to-live for cached responses.
-	TTL time.Duration
+	TTL time.Duration `json:"ttl"`
+
+	// StorageType is the Go type name of the storage backend (e.g. "*idem.MemoryStorage").
+	StorageType string `json:"storage_type"`
+
+	// LockSupported indicates whether the storage backend implements the Locker interface.
+	LockSupported bool `json:"lock_supported"`
+
+	// MetricsEnabled indicates whether metrics callbacks are configured.
+	MetricsEnabled bool `json:"metrics_enabled"`
+
+	// OnErrorEnabled indicates whether an error callback is configured.
+	OnErrorEnabled bool `json:"on_error_enabled"`
+
+	// ValidatorCount is the number of registered validators.
+	ValidatorCount int `json:"validator_count"`
 }
 
 // Validator is a function that inspects the middleware configuration and
@@ -38,10 +57,29 @@ type config struct {
 }
 
 func (c *config) snapshot() Config {
-	return Config{
-		KeyHeader: c.keyHeader,
-		TTL:       c.ttl,
+	cfg := Config{
+		KeyHeader:      c.keyHeader,
+		TTL:            c.ttl,
+		ValidatorCount: len(c.validators),
 	}
+
+	if c.storage != nil {
+		cfg.StorageType = fmt.Sprintf("%T", c.storage)
+		_, cfg.LockSupported = c.storage.(Locker)
+	}
+
+	cfg.MetricsEnabled = c.metrics != nil
+	cfg.OnErrorEnabled = c.onError != nil
+
+	return cfg
+}
+
+// String returns a human-readable summary of the configuration.
+func (c Config) String() string {
+	return fmt.Sprintf(
+		"idem.Config{KeyHeader: %q, TTL: %v, StorageType: %s, LockSupported: %t, MetricsEnabled: %t}",
+		c.KeyHeader, c.TTL, c.StorageType, c.LockSupported, c.MetricsEnabled,
+	)
 }
 
 // defaultConfig returns a config with sensible defaults.

--- a/option_test.go
+++ b/option_test.go
@@ -3,6 +3,7 @@ package idem
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 )
@@ -296,19 +297,146 @@ func TestWithValidation(t *testing.T) {
 func TestConfig_snapshot(t *testing.T) {
 	t.Parallel()
 
-	cfg := &config{
-		keyHeader: "X-Custom-Key",
-		ttl:       10 * time.Minute,
-	}
+	t.Run("basic fields", func(t *testing.T) {
+		t.Parallel()
 
-	snap := cfg.snapshot()
+		cfg := &config{
+			keyHeader: "X-Custom-Key",
+			ttl:       10 * time.Minute,
+		}
 
-	if snap.KeyHeader != cfg.keyHeader {
-		t.Errorf("KeyHeader = %q, want %q", snap.KeyHeader, cfg.keyHeader)
-	}
-	if snap.TTL != cfg.ttl {
-		t.Errorf("TTL = %v, want %v", snap.TTL, cfg.ttl)
-	}
+		snap := cfg.snapshot()
+
+		if snap.KeyHeader != cfg.keyHeader {
+			t.Errorf("KeyHeader = %q, want %q", snap.KeyHeader, cfg.keyHeader)
+		}
+		if snap.TTL != cfg.ttl {
+			t.Errorf("TTL = %v, want %v", snap.TTL, cfg.ttl)
+		}
+	})
+
+	t.Run("StorageType is empty when storage is nil", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := defaultConfig()
+		snap := cfg.snapshot()
+
+		if snap.StorageType != "" {
+			t.Errorf("StorageType = %q, want empty", snap.StorageType)
+		}
+	})
+
+	t.Run("StorageType reflects MemoryStorage type name", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := defaultConfig()
+		cfg.storage = NewMemoryStorage()
+		snap := cfg.snapshot()
+
+		if snap.StorageType != "*idem.MemoryStorage" {
+			t.Errorf("StorageType = %q, want %q", snap.StorageType, "*idem.MemoryStorage")
+		}
+	})
+
+	t.Run("LockSupported is true when storage implements Locker", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := defaultConfig()
+		cfg.storage = NewMemoryStorage()
+		snap := cfg.snapshot()
+
+		if !snap.LockSupported {
+			t.Error("LockSupported = false, want true")
+		}
+	})
+
+	t.Run("LockSupported is false when storage does not implement Locker", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := defaultConfig()
+		cfg.storage = &stubStorage{}
+		snap := cfg.snapshot()
+
+		if snap.LockSupported {
+			t.Error("LockSupported = true, want false")
+		}
+	})
+
+	t.Run("MetricsEnabled reflects metrics presence", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := defaultConfig()
+		if cfg.snapshot().MetricsEnabled {
+			t.Error("MetricsEnabled = true without metrics, want false")
+		}
+
+		WithMetrics(Metrics{})(cfg)
+		if !cfg.snapshot().MetricsEnabled {
+			t.Error("MetricsEnabled = false with metrics, want true")
+		}
+	})
+
+	t.Run("OnErrorEnabled reflects onError presence", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := defaultConfig()
+		if cfg.snapshot().OnErrorEnabled {
+			t.Error("OnErrorEnabled = true without onError, want false")
+		}
+
+		WithOnError(func(_ error) {})(cfg)
+		if !cfg.snapshot().OnErrorEnabled {
+			t.Error("OnErrorEnabled = false with onError, want true")
+		}
+	})
+
+	t.Run("ValidatorCount reflects registered validators", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := defaultConfig()
+		if cfg.snapshot().ValidatorCount != 0 {
+			t.Errorf("ValidatorCount = %d, want 0", cfg.snapshot().ValidatorCount)
+		}
+
+		WithValidation(
+			func(_ Config) error { return nil },
+			func(_ Config) error { return nil },
+		)(cfg)
+
+		if cfg.snapshot().ValidatorCount != 2 {
+			t.Errorf("ValidatorCount = %d, want 2", cfg.snapshot().ValidatorCount)
+		}
+	})
+}
+
+func TestConfig_String(t *testing.T) {
+	t.Parallel()
+
+	t.Run("contains all key fields", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := Config{
+			KeyHeader:      "Idempotency-Key",
+			TTL:            24 * time.Hour,
+			StorageType:    "*idem.MemoryStorage",
+			LockSupported:  true,
+			MetricsEnabled: true,
+		}
+
+		s := cfg.String()
+		for _, want := range []string{"Idempotency-Key", "24h0m0s", "*idem.MemoryStorage", "true"} {
+			if !strings.Contains(s, want) {
+				t.Errorf("String() = %q, missing %q", s, want)
+			}
+		}
+	})
+
+	t.Run("does not panic on zero value", func(t *testing.T) {
+		t.Parallel()
+
+		var cfg Config
+		_ = cfg.String()
+	})
 }
 
 func TestNew_withCustomValidation(t *testing.T) {


### PR DESCRIPTION
## Summary
- Extended `Config` struct with `StorageType`, `LockSupported`, `MetricsEnabled`, `OnErrorEnabled`, and `ValidatorCount` fields with JSON tags
- Implemented `fmt.Stringer` on `Config` for debug log output
- Added `Middleware.Config()` accessor to retrieve a read-only configuration snapshot
- Added comprehensive unit tests for `snapshot()`, `Config.String()`, and `Middleware.Config()`
- Updated README with "Configuration Inspection" section showing debug logging and JSON endpoint examples

## Test plan
- [x] `snapshot()` correctly populates all new fields (storage type, lock support, metrics, onError, validators)
- [x] `snapshot()` handles nil storage safely
- [x] `Config.String()` includes all key fields and does not panic on zero value
- [x] `Middleware.Config()` returns correct defaults and reflects custom options
- [x] All existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)