### PR TITLE
Close #105: Fix Gin wrapMiddleware to enable idempotent cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,6 +294,8 @@ curl -X POST http://localhost:8080/orders -H "Idempotency-Key: key-123"
 
 See [`_examples/gin/main.go`](./_examples/gin/main.go) for the full source including per-endpoint and route-group middleware patterns.
 
+> **Note:** The `wrapMiddleware` helper replaces `c.Writer` with a dual-write adapter (`recorderGinWriter`) so that Gin's `c.JSON()` writes flow through idem's response recorder for caching. On a cache hit, the inner handler is not called and `c.Abort()` is used to stop the Gin handler chain.
+
 ### Echo
 
 ```bash

--- a/_examples/gin/main.go
+++ b/_examples/gin/main.go
@@ -1,8 +1,10 @@
 package main
 
 import (
+	"bufio"
 	"fmt"
 	"log"
+	"net"
 	"net/http"
 	"sync/atomic"
 
@@ -55,9 +57,77 @@ func main() {
 func wrapMiddleware(m *idem.Middleware) gin.HandlerFunc {
 	handler := m.Handler()
 	return func(c *gin.Context) {
+		var innerCalled bool
 		handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			innerCalled = true
 			c.Request = r
+			// Replace Gin's writer so that c.JSON() writes through
+			// idem's responseRecorder, enabling response capture.
+			c.Writer = &recorderGinWriter{
+				ResponseWriter: w,
+				ginWriter:      c.Writer,
+			}
 			c.Next()
 		})).ServeHTTP(c.Writer, c.Request)
+
+		if !innerCalled {
+			// Cache hit: idem already wrote the response.
+			// Abort prevents Gin from running subsequent handlers.
+			c.Abort()
+		}
 	}
+}
+
+// recorderGinWriter wraps idem's responseRecorder while satisfying
+// gin.ResponseWriter so that Gin helpers (c.JSON, etc.) work correctly.
+type recorderGinWriter struct {
+	http.ResponseWriter
+	ginWriter gin.ResponseWriter
+}
+
+func (w *recorderGinWriter) WriteHeader(code int) {
+	w.ginWriter.WriteHeader(code)
+	w.ResponseWriter.WriteHeader(code)
+}
+
+func (w *recorderGinWriter) Write(data []byte) (int, error) {
+	w.ginWriter.Write(data)
+	return w.ResponseWriter.Write(data)
+}
+
+func (w *recorderGinWriter) WriteString(s string) (int, error) {
+	w.ginWriter.WriteString(s)
+	return w.ResponseWriter.Write([]byte(s))
+}
+
+func (w *recorderGinWriter) Status() int {
+	return w.ginWriter.Status()
+}
+
+func (w *recorderGinWriter) Size() int {
+	return w.ginWriter.Size()
+}
+
+func (w *recorderGinWriter) Written() bool {
+	return w.ginWriter.Written()
+}
+
+func (w *recorderGinWriter) WriteHeaderNow() {
+	w.ginWriter.WriteHeaderNow()
+}
+
+func (w *recorderGinWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	return w.ginWriter.Hijack()
+}
+
+func (w *recorderGinWriter) Flush() {
+	w.ginWriter.Flush()
+}
+
+func (w *recorderGinWriter) CloseNotify() <-chan bool {
+	return w.ginWriter.CloseNotify()
+}
+
+func (w *recorderGinWriter) Pusher() http.Pusher {
+	return w.ginWriter.Pusher()
 }

--- a/_examples/nginx-redis-gin/main.go
+++ b/_examples/nginx-redis-gin/main.go
@@ -1,8 +1,10 @@
 package main
 
 import (
+	"bufio"
 	"fmt"
 	"log"
+	"net"
 	"net/http"
 	"os"
 	"sync/atomic"
@@ -70,9 +72,77 @@ func main() {
 func wrapMiddleware(m *idem.Middleware) gin.HandlerFunc {
 	handler := m.Handler()
 	return func(c *gin.Context) {
+		var innerCalled bool
 		handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			innerCalled = true
 			c.Request = r
+			// Replace Gin's writer so that c.JSON() writes through
+			// idem's responseRecorder, enabling response capture.
+			c.Writer = &recorderGinWriter{
+				ResponseWriter: w,
+				ginWriter:      c.Writer,
+			}
 			c.Next()
 		})).ServeHTTP(c.Writer, c.Request)
+
+		if !innerCalled {
+			// Cache hit: idem already wrote the response.
+			// Abort prevents Gin from running subsequent handlers.
+			c.Abort()
+		}
 	}
+}
+
+// recorderGinWriter wraps idem's responseRecorder while satisfying
+// gin.ResponseWriter so that Gin helpers (c.JSON, etc.) work correctly.
+type recorderGinWriter struct {
+	http.ResponseWriter
+	ginWriter gin.ResponseWriter
+}
+
+func (w *recorderGinWriter) WriteHeader(code int) {
+	w.ginWriter.WriteHeader(code)
+	w.ResponseWriter.WriteHeader(code)
+}
+
+func (w *recorderGinWriter) Write(data []byte) (int, error) {
+	w.ginWriter.Write(data)
+	return w.ResponseWriter.Write(data)
+}
+
+func (w *recorderGinWriter) WriteString(s string) (int, error) {
+	w.ginWriter.WriteString(s)
+	return w.ResponseWriter.Write([]byte(s))
+}
+
+func (w *recorderGinWriter) Status() int {
+	return w.ginWriter.Status()
+}
+
+func (w *recorderGinWriter) Size() int {
+	return w.ginWriter.Size()
+}
+
+func (w *recorderGinWriter) Written() bool {
+	return w.ginWriter.Written()
+}
+
+func (w *recorderGinWriter) WriteHeaderNow() {
+	w.ginWriter.WriteHeaderNow()
+}
+
+func (w *recorderGinWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	return w.ginWriter.Hijack()
+}
+
+func (w *recorderGinWriter) Flush() {
+	w.ginWriter.Flush()
+}
+
+func (w *recorderGinWriter) CloseNotify() <-chan bool {
+	return w.ginWriter.CloseNotify()
+}
+
+func (w *recorderGinWriter) Pusher() http.Pusher {
+	return w.ginWriter.Pusher()
 }

--- a/_examples/prometheus-gin/main.go
+++ b/_examples/prometheus-gin/main.go
@@ -1,8 +1,10 @@
 package main
 
 import (
+	"bufio"
 	"fmt"
 	"log"
+	"net"
 	"net/http"
 	"sync/atomic"
 
@@ -83,9 +85,77 @@ func main() {
 func wrapMiddleware(m *idem.Middleware) gin.HandlerFunc {
 	handler := m.Handler()
 	return func(c *gin.Context) {
+		var innerCalled bool
 		handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			innerCalled = true
 			c.Request = r
+			// Replace Gin's writer so that c.JSON() writes through
+			// idem's responseRecorder, enabling response capture.
+			c.Writer = &recorderGinWriter{
+				ResponseWriter: w,
+				ginWriter:      c.Writer,
+			}
 			c.Next()
 		})).ServeHTTP(c.Writer, c.Request)
+
+		if !innerCalled {
+			// Cache hit: idem already wrote the response.
+			// Abort prevents Gin from running subsequent handlers.
+			c.Abort()
+		}
 	}
+}
+
+// recorderGinWriter wraps idem's responseRecorder while satisfying
+// gin.ResponseWriter so that Gin helpers (c.JSON, etc.) work correctly.
+type recorderGinWriter struct {
+	http.ResponseWriter
+	ginWriter gin.ResponseWriter
+}
+
+func (w *recorderGinWriter) WriteHeader(code int) {
+	w.ginWriter.WriteHeader(code)
+	w.ResponseWriter.WriteHeader(code)
+}
+
+func (w *recorderGinWriter) Write(data []byte) (int, error) {
+	w.ginWriter.Write(data)
+	return w.ResponseWriter.Write(data)
+}
+
+func (w *recorderGinWriter) WriteString(s string) (int, error) {
+	w.ginWriter.WriteString(s)
+	return w.ResponseWriter.Write([]byte(s))
+}
+
+func (w *recorderGinWriter) Status() int {
+	return w.ginWriter.Status()
+}
+
+func (w *recorderGinWriter) Size() int {
+	return w.ginWriter.Size()
+}
+
+func (w *recorderGinWriter) Written() bool {
+	return w.ginWriter.Written()
+}
+
+func (w *recorderGinWriter) WriteHeaderNow() {
+	w.ginWriter.WriteHeaderNow()
+}
+
+func (w *recorderGinWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	return w.ginWriter.Hijack()
+}
+
+func (w *recorderGinWriter) Flush() {
+	w.ginWriter.Flush()
+}
+
+func (w *recorderGinWriter) CloseNotify() <-chan bool {
+	return w.ginWriter.CloseNotify()
+}
+
+func (w *recorderGinWriter) Pusher() http.Pusher {
+	return w.ginWriter.Pusher()
 }

--- a/_examples/redis-cluster-gin/main.go
+++ b/_examples/redis-cluster-gin/main.go
@@ -1,8 +1,10 @@
 package main
 
 import (
+	"bufio"
 	"fmt"
 	"log"
+	"net"
 	"net/http"
 	"os"
 	"strings"
@@ -73,9 +75,77 @@ func main() {
 func wrapMiddleware(m *idem.Middleware) gin.HandlerFunc {
 	handler := m.Handler()
 	return func(c *gin.Context) {
+		var innerCalled bool
 		handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			innerCalled = true
 			c.Request = r
+			// Replace Gin's writer so that c.JSON() writes through
+			// idem's responseRecorder, enabling response capture.
+			c.Writer = &recorderGinWriter{
+				ResponseWriter: w,
+				ginWriter:      c.Writer,
+			}
 			c.Next()
 		})).ServeHTTP(c.Writer, c.Request)
+
+		if !innerCalled {
+			// Cache hit: idem already wrote the response.
+			// Abort prevents Gin from running subsequent handlers.
+			c.Abort()
+		}
 	}
+}
+
+// recorderGinWriter wraps idem's responseRecorder while satisfying
+// gin.ResponseWriter so that Gin helpers (c.JSON, etc.) work correctly.
+type recorderGinWriter struct {
+	http.ResponseWriter
+	ginWriter gin.ResponseWriter
+}
+
+func (w *recorderGinWriter) WriteHeader(code int) {
+	w.ginWriter.WriteHeader(code)
+	w.ResponseWriter.WriteHeader(code)
+}
+
+func (w *recorderGinWriter) Write(data []byte) (int, error) {
+	w.ginWriter.Write(data)
+	return w.ResponseWriter.Write(data)
+}
+
+func (w *recorderGinWriter) WriteString(s string) (int, error) {
+	w.ginWriter.WriteString(s)
+	return w.ResponseWriter.Write([]byte(s))
+}
+
+func (w *recorderGinWriter) Status() int {
+	return w.ginWriter.Status()
+}
+
+func (w *recorderGinWriter) Size() int {
+	return w.ginWriter.Size()
+}
+
+func (w *recorderGinWriter) Written() bool {
+	return w.ginWriter.Written()
+}
+
+func (w *recorderGinWriter) WriteHeaderNow() {
+	w.ginWriter.WriteHeaderNow()
+}
+
+func (w *recorderGinWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	return w.ginWriter.Hijack()
+}
+
+func (w *recorderGinWriter) Flush() {
+	w.ginWriter.Flush()
+}
+
+func (w *recorderGinWriter) CloseNotify() <-chan bool {
+	return w.ginWriter.CloseNotify()
+}
+
+func (w *recorderGinWriter) Pusher() http.Pusher {
+	return w.ginWriter.Pusher()
 }

--- a/_examples/redis-gin/main.go
+++ b/_examples/redis-gin/main.go
@@ -1,8 +1,10 @@
 package main
 
 import (
+	"bufio"
 	"fmt"
 	"log"
+	"net"
 	"net/http"
 	"os"
 	"sync/atomic"
@@ -70,9 +72,77 @@ func main() {
 func wrapMiddleware(m *idem.Middleware) gin.HandlerFunc {
 	handler := m.Handler()
 	return func(c *gin.Context) {
+		var innerCalled bool
 		handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			innerCalled = true
 			c.Request = r
+			// Replace Gin's writer so that c.JSON() writes through
+			// idem's responseRecorder, enabling response capture.
+			c.Writer = &recorderGinWriter{
+				ResponseWriter: w,
+				ginWriter:      c.Writer,
+			}
 			c.Next()
 		})).ServeHTTP(c.Writer, c.Request)
+
+		if !innerCalled {
+			// Cache hit: idem already wrote the response.
+			// Abort prevents Gin from running subsequent handlers.
+			c.Abort()
+		}
 	}
+}
+
+// recorderGinWriter wraps idem's responseRecorder while satisfying
+// gin.ResponseWriter so that Gin helpers (c.JSON, etc.) work correctly.
+type recorderGinWriter struct {
+	http.ResponseWriter
+	ginWriter gin.ResponseWriter
+}
+
+func (w *recorderGinWriter) WriteHeader(code int) {
+	w.ginWriter.WriteHeader(code)
+	w.ResponseWriter.WriteHeader(code)
+}
+
+func (w *recorderGinWriter) Write(data []byte) (int, error) {
+	w.ginWriter.Write(data)
+	return w.ResponseWriter.Write(data)
+}
+
+func (w *recorderGinWriter) WriteString(s string) (int, error) {
+	w.ginWriter.WriteString(s)
+	return w.ResponseWriter.Write([]byte(s))
+}
+
+func (w *recorderGinWriter) Status() int {
+	return w.ginWriter.Status()
+}
+
+func (w *recorderGinWriter) Size() int {
+	return w.ginWriter.Size()
+}
+
+func (w *recorderGinWriter) Written() bool {
+	return w.ginWriter.Written()
+}
+
+func (w *recorderGinWriter) WriteHeaderNow() {
+	w.ginWriter.WriteHeaderNow()
+}
+
+func (w *recorderGinWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	return w.ginWriter.Hijack()
+}
+
+func (w *recorderGinWriter) Flush() {
+	w.ginWriter.Flush()
+}
+
+func (w *recorderGinWriter) CloseNotify() <-chan bool {
+	return w.ginWriter.CloseNotify()
+}
+
+func (w *recorderGinWriter) Pusher() http.Pusher {
+	return w.ginWriter.Pusher()
 }

--- a/_examples/redis-sentinel-gin/main.go
+++ b/_examples/redis-sentinel-gin/main.go
@@ -1,8 +1,10 @@
 package main
 
 import (
+	"bufio"
 	"fmt"
 	"log"
+	"net"
 	"net/http"
 	"os"
 	"strings"
@@ -79,9 +81,77 @@ func main() {
 func wrapMiddleware(m *idem.Middleware) gin.HandlerFunc {
 	handler := m.Handler()
 	return func(c *gin.Context) {
+		var innerCalled bool
 		handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			innerCalled = true
 			c.Request = r
+			// Replace Gin's writer so that c.JSON() writes through
+			// idem's responseRecorder, enabling response capture.
+			c.Writer = &recorderGinWriter{
+				ResponseWriter: w,
+				ginWriter:      c.Writer,
+			}
 			c.Next()
 		})).ServeHTTP(c.Writer, c.Request)
+
+		if !innerCalled {
+			// Cache hit: idem already wrote the response.
+			// Abort prevents Gin from running subsequent handlers.
+			c.Abort()
+		}
 	}
+}
+
+// recorderGinWriter wraps idem's responseRecorder while satisfying
+// gin.ResponseWriter so that Gin helpers (c.JSON, etc.) work correctly.
+type recorderGinWriter struct {
+	http.ResponseWriter
+	ginWriter gin.ResponseWriter
+}
+
+func (w *recorderGinWriter) WriteHeader(code int) {
+	w.ginWriter.WriteHeader(code)
+	w.ResponseWriter.WriteHeader(code)
+}
+
+func (w *recorderGinWriter) Write(data []byte) (int, error) {
+	w.ginWriter.Write(data)
+	return w.ResponseWriter.Write(data)
+}
+
+func (w *recorderGinWriter) WriteString(s string) (int, error) {
+	w.ginWriter.WriteString(s)
+	return w.ResponseWriter.Write([]byte(s))
+}
+
+func (w *recorderGinWriter) Status() int {
+	return w.ginWriter.Status()
+}
+
+func (w *recorderGinWriter) Size() int {
+	return w.ginWriter.Size()
+}
+
+func (w *recorderGinWriter) Written() bool {
+	return w.ginWriter.Written()
+}
+
+func (w *recorderGinWriter) WriteHeaderNow() {
+	w.ginWriter.WriteHeaderNow()
+}
+
+func (w *recorderGinWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	return w.ginWriter.Hijack()
+}
+
+func (w *recorderGinWriter) Flush() {
+	w.ginWriter.Flush()
+}
+
+func (w *recorderGinWriter) CloseNotify() <-chan bool {
+	return w.ginWriter.CloseNotify()
+}
+
+func (w *recorderGinWriter) Pusher() http.Pusher {
+	return w.ginWriter.Pusher()
 }


### PR DESCRIPTION
## Summary
- Fix Gin `wrapMiddleware` in all 6 Gin examples to correctly capture responses and handle cache hits
- Add `recorderGinWriter` adapter that dual-writes to both Gin's `ResponseWriter` and idem's `responseRecorder`, ensuring `c.JSON()` output is captured for caching
- Call `c.Abort()` on cache hit (when inner handler is not invoked) to prevent Gin from executing subsequent handlers
- Add a note to README explaining the Gin integration approach

## Test plan
- [x] All 5 buildable Gin examples compile successfully (`go build`)
- [x] `go vet` passes on all examples
- [x] Root package tests pass (`go test -short ./...`)
- [ ] Manual test: run `_examples/gin` and verify duplicate `Idempotency-Key` requests return cached response
- [ ] Manual test: verify no `Headers were already written` warnings from Gin

🤖 Generated with [Claude Code](https://claude.com/claude-code)