### PR TITLE
Close #106: Remove invalid COPY memory/ from example Dockerfiles

### DIFF
--- a/_examples/prometheus-gin/Dockerfile
+++ b/_examples/prometheus-gin/Dockerfile
@@ -5,7 +5,6 @@ WORKDIR /src
 # Copy root module (idem library)
 COPY go.mod go.sum ./
 COPY *.go ./
-COPY memory/ memory/
 
 # Copy example module
 COPY _examples/prometheus-gin/ ./_examples/prometheus-gin/

--- a/_examples/redis-cluster-gin/Dockerfile
+++ b/_examples/redis-cluster-gin/Dockerfile
@@ -5,7 +5,6 @@ WORKDIR /src
 # Copy root module (idem library)
 COPY go.mod go.sum ./
 COPY *.go ./
-COPY memory/ memory/
 COPY redis/ redis/
 
 # Copy example module

--- a/_examples/redis-sentinel-gin/Dockerfile
+++ b/_examples/redis-sentinel-gin/Dockerfile
@@ -5,7 +5,6 @@ WORKDIR /src
 # Copy root module (idem library)
 COPY go.mod go.sum ./
 COPY *.go ./
-COPY memory/ memory/
 COPY redis/ redis/
 
 # Copy example module


### PR DESCRIPTION
## Summary
- Remove `COPY memory/ memory/` from `_examples/prometheus-gin/Dockerfile`, `_examples/redis-cluster-gin/Dockerfile`, and `_examples/redis-sentinel-gin/Dockerfile`
- The `memory/` directory does not exist at the project root — `MemoryStorage` is defined in the root package (`idem.go`) and is already copied via `COPY *.go ./`
- Also fixes `redis-sentinel-gin/Dockerfile` (added in #107) which had the same issue not reported in the original issue

## Test plan
- [ ] `cd _examples/prometheus-gin && docker compose up --build` succeeds
- [ ] `cd _examples/redis-cluster-gin && docker compose up --build` succeeds
- [ ] `cd _examples/redis-sentinel-gin && docker compose up --build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)