### PR TITLE
Close #16: API review breaking changes final adjustment

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,6 @@ make shell          # Interactive bash in container
 
 - **Root package (`idem`)**: Core types and middleware — `idem.go`, `middleware.go`, `storage.go`, `locker.go`, `response.go`, `option.go`. Generated files: `recorder_gen.go`, `recorder_gen_test.go`
 - **`internal/cmd/genrecorder/`**: Code generator for `responseRecorder` combination types (run via `go generate ./...`)
-- **`memory/`**: In-memory storage implementation
 - **`redis/`**: Redis storage implementation
 - **`_examples/`**: Framework-specific usage examples (Gin, Echo, Chi)
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ The first request executes the handler and caches the response. Subsequent reque
 | `WithKeyHeader(h)` | `"Idempotency-Key"` | Header name to read the idempotency key from |
 | `WithTTL(d)` | `24h` | Cache duration for stored responses |
 | `WithStorage(s)` | In-memory | Storage backend for cached responses |
-| `WithOnError(fn)` | `nil` | Callback invoked when a storage operation fails |
+| `WithOnError(fn)` | `nil` | Callback invoked when a storage operation fails (receives key and error) |
 | `WithMetrics(m)` | `nil` | Callbacks for observing cache hits, misses, and errors |
 | `WithValidation(v...)` | none | Custom validators run during `New()` after built-in checks |
 
@@ -72,8 +72,8 @@ mw, err := idem.New(
 	idem.WithKeyHeader("X-Request-Id"),
 	idem.WithTTL(1 * time.Hour),
 	idem.WithStorage(redisStore),
-	idem.WithOnError(func(err error) {
-		log.Printf("storage error: %v", err)
+	idem.WithOnError(func(key string, err error) {
+		log.Printf("storage error: key=%s err=%v", key, err)
 	}),
 )
 if err != nil {

--- a/_examples/nginx-redis-gin/main.go
+++ b/_examples/nginx-redis-gin/main.go
@@ -35,8 +35,8 @@ func main() {
 
 	idempotency, err := idem.New(
 		idem.WithStorage(store),
-		idem.WithOnError(func(err error) {
-			log.Printf("[idem] error: %v", err)
+		idem.WithOnError(func(key string, err error) {
+			log.Printf("[idem] error: key=%s err=%v", key, err)
 		}),
 	)
 	if err != nil {

--- a/_examples/redis-cluster-gin/main.go
+++ b/_examples/redis-cluster-gin/main.go
@@ -38,8 +38,8 @@ func main() {
 
 	idempotency, err := idem.New(
 		idem.WithStorage(store),
-		idem.WithOnError(func(err error) {
-			log.Printf("[idem] error: %v", err)
+		idem.WithOnError(func(key string, err error) {
+			log.Printf("[idem] error: key=%s err=%v", key, err)
 		}),
 	)
 	if err != nil {

--- a/_examples/redis-gin/main.go
+++ b/_examples/redis-gin/main.go
@@ -35,8 +35,8 @@ func main() {
 
 	idempotency, err := idem.New(
 		idem.WithStorage(store),
-		idem.WithOnError(func(err error) {
-			log.Printf("[idem] error: %v", err)
+		idem.WithOnError(func(key string, err error) {
+			log.Printf("[idem] error: key=%s err=%v", key, err)
 		}),
 	)
 	if err != nil {

--- a/_examples/redis-sentinel-gin/main.go
+++ b/_examples/redis-sentinel-gin/main.go
@@ -44,8 +44,8 @@ func main() {
 
 	idempotency, err := idem.New(
 		idem.WithStorage(store),
-		idem.WithOnError(func(err error) {
-			log.Printf("[idem] error: %v", err)
+		idem.WithOnError(func(key string, err error) {
+			log.Printf("[idem] error: key=%s err=%v", key, err)
 		}),
 	)
 	if err != nil {

--- a/idem_test.go
+++ b/idem_test.go
@@ -105,7 +105,7 @@ func TestMemoryStorage_Get(t *testing.T) {
 
 	res := &Response{
 		StatusCode: http.StatusOK,
-		Header:     map[string][]string{"Content-Type": {"application/json"}},
+		Header:     http.Header{"Content-Type": {"application/json"}},
 		Body:       []byte(`{"ok":true}`),
 	}
 
@@ -171,9 +171,9 @@ func TestMemoryStorage_Get(t *testing.T) {
 			if got.StatusCode != tt.wantRes.StatusCode {
 				t.Errorf("StatusCode = %d, want %d", got.StatusCode, tt.wantRes.StatusCode)
 			}
-			if http.Header(got.Header).Get("Content-Type") != http.Header(tt.wantRes.Header).Get("Content-Type") {
+			if got.Header.Get("Content-Type") != tt.wantRes.Header.Get("Content-Type") {
 				t.Errorf("Header Content-Type = %q, want %q",
-					http.Header(got.Header).Get("Content-Type"), http.Header(tt.wantRes.Header).Get("Content-Type"))
+					got.Header.Get("Content-Type"), tt.wantRes.Header.Get("Content-Type"))
 			}
 			if string(got.Body) != string(tt.wantRes.Body) {
 				t.Errorf("Body = %q, want %q", got.Body, tt.wantRes.Body)

--- a/middleware.go
+++ b/middleware.go
@@ -37,9 +37,6 @@ func (m *Middleware) Handler() func(http.Handler) http.Handler {
 			if locker, ok := m.cfg.storage.(Locker); ok {
 				unlock, err := locker.Lock(r.Context(), key, m.cfg.ttl)
 				if err != nil {
-					if m.cfg.onError != nil {
-						m.cfg.onError(err)
-					}
 					if m.cfg.metrics != nil && m.cfg.metrics.OnLockContention != nil {
 						m.cfg.metrics.OnLockContention(key, err)
 					}
@@ -52,7 +49,7 @@ func (m *Middleware) Handler() func(http.Handler) http.Handler {
 			cached, err := m.cfg.storage.Get(r.Context(), key)
 			if err != nil {
 				if m.cfg.onError != nil {
-					m.cfg.onError(err)
+					m.cfg.onError(key, err)
 				}
 				if m.cfg.metrics != nil && m.cfg.metrics.OnError != nil {
 					m.cfg.metrics.OnError(key, err)
@@ -80,7 +77,7 @@ func (m *Middleware) Handler() func(http.Handler) http.Handler {
 			res := rr.toResponse()
 			if err := m.cfg.storage.Set(r.Context(), key, res, m.cfg.ttl); err != nil {
 				if m.cfg.onError != nil {
-					m.cfg.onError(err)
+					m.cfg.onError(key, err)
 				}
 				if m.cfg.metrics != nil && m.cfg.metrics.OnError != nil {
 					m.cfg.metrics.OnError(key, err)
@@ -122,7 +119,7 @@ func (r *responseRecorder) Write(b []byte) (int, error) {
 }
 
 func (r *responseRecorder) toResponse() *Response {
-	header := make(map[string][]string)
+	header := make(http.Header)
 	for k, v := range r.Header() {
 		header[k] = append([]string(nil), v...)
 	}

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -224,18 +224,26 @@ func TestMiddleware_Handler(t *testing.T) {
 		t.Parallel()
 
 		getErr := errors.New("get failed")
+		var gotKey string
 		var gotErr error
 		handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			w.WriteHeader(http.StatusOK)
 		})
 
 		store := &errorStorage{getErr: getErr}
-		mw := newTestMiddleware(t, WithStorage(store), WithOnError(func(err error) { gotErr = err }))
+		mw := newTestMiddleware(t, WithStorage(store), WithOnError(func(key string, err error) {
+			gotKey = key
+			gotErr = err
+		}))
 		wrapped := mw.Handler()(handler)
 
 		req := httptest.NewRequest(http.MethodPost, "/", nil)
 		req.Header.Set("Idempotency-Key", "err-key")
 		wrapped.ServeHTTP(httptest.NewRecorder(), req)
+
+		if gotKey != "err-key" {
+			t.Errorf("onError key = %q, want %q", gotKey, "err-key")
+		}
 
 		if !errors.Is(gotErr, getErr) {
 			t.Errorf("onError received %v, want %v", gotErr, getErr)
@@ -246,19 +254,27 @@ func TestMiddleware_Handler(t *testing.T) {
 		t.Parallel()
 
 		setErr := errors.New("set failed")
+		var gotKey string
 		var gotErr error
 		handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			w.WriteHeader(http.StatusOK)
 		})
 
 		store := &errorStorage{setErr: setErr}
-		mw := newTestMiddleware(t, WithStorage(store), WithOnError(func(err error) { gotErr = err }))
+		mw := newTestMiddleware(t, WithStorage(store), WithOnError(func(key string, err error) {
+			gotKey = key
+			gotErr = err
+		}))
 		wrapped := mw.Handler()(handler)
 
 		req := httptest.NewRequest(http.MethodPost, "/", nil)
 		req.Header.Set("Idempotency-Key", "err-key")
 		rec := httptest.NewRecorder()
 		wrapped.ServeHTTP(rec, req)
+
+		if gotKey != "err-key" {
+			t.Errorf("onError key = %q, want %q", gotKey, "err-key")
+		}
 
 		if !errors.Is(gotErr, setErr) {
 			t.Errorf("onError received %v, want %v", gotErr, setErr)
@@ -321,25 +337,25 @@ func TestMiddleware_Handler(t *testing.T) {
 		}
 	})
 
-	t.Run("calls onError callback when lock acquisition fails", func(t *testing.T) {
+	t.Run("does not call onError callback when lock acquisition fails", func(t *testing.T) {
 		t.Parallel()
 
 		lockErr := errors.New("lock failed")
-		var gotErr error
+		var onErrorCalled bool
 		handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			w.WriteHeader(http.StatusOK)
 		})
 
 		store := &errorLockerStorage{lockErr: lockErr}
-		mw := newTestMiddleware(t, WithStorage(store), WithOnError(func(err error) { gotErr = err }))
+		mw := newTestMiddleware(t, WithStorage(store), WithOnError(func(_ string, _ error) { onErrorCalled = true }))
 		wrapped := mw.Handler()(handler)
 
 		req := httptest.NewRequest(http.MethodPost, "/", nil)
 		req.Header.Set("Idempotency-Key", "err-lock-key")
 		wrapped.ServeHTTP(httptest.NewRecorder(), req)
 
-		if !errors.Is(gotErr, lockErr) {
-			t.Errorf("onError received %v, want %v", gotErr, lockErr)
+		if onErrorCalled {
+			t.Error("WithOnError callback was called on lock contention, want not called")
 		}
 	})
 
@@ -536,7 +552,7 @@ func TestMiddleware_Handler(t *testing.T) {
 		store := &errorStorage{getErr: getErr}
 		mw := newTestMiddleware(t,
 			WithStorage(store),
-			WithOnError(func(_ error) { onErrorCalled = true }),
+			WithOnError(func(_ string, _ error) { onErrorCalled = true }),
 			WithMetrics(Metrics{
 				OnError: func(_ string, _ error) { metricsErrorCalled = true },
 			}),
@@ -669,7 +685,7 @@ func TestMiddleware_Config(t *testing.T) {
 			WithKeyHeader("X-Request-Id"),
 			WithTTL(5*time.Minute),
 			WithStorage(&stubStorage{}),
-			WithOnError(func(_ error) {}),
+			WithOnError(func(_ string, _ error) {}),
 			WithMetrics(Metrics{}),
 			WithValidation(func(_ Config) error { return nil }),
 		)

--- a/option.go
+++ b/option.go
@@ -27,6 +27,10 @@ type Config struct {
 	// TTL is the time-to-live for cached responses.
 	TTL time.Duration `json:"ttl"`
 
+	// KeyMaxLength is the maximum allowed length for idempotency key values.
+	// A value of 0 means no length limit.
+	KeyMaxLength int `json:"key_max_length"`
+
 	// StorageType is the Go type name of the storage backend (e.g. "*idem.MemoryStorage").
 	StorageType string `json:"storage_type"`
 
@@ -52,7 +56,7 @@ type config struct {
 	ttl          time.Duration
 	keyMaxLength int
 	storage      Storage
-	onError      func(error)
+	onError      func(key string, err error)
 	metrics      *Metrics
 	validators   []Validator
 }
@@ -61,6 +65,7 @@ func (c *config) snapshot() Config {
 	cfg := Config{
 		KeyHeader:      c.keyHeader,
 		TTL:            c.ttl,
+		KeyMaxLength:   c.keyMaxLength,
 		ValidatorCount: len(c.validators),
 	}
 
@@ -78,8 +83,8 @@ func (c *config) snapshot() Config {
 // String returns a human-readable summary of the configuration.
 func (c Config) String() string {
 	return fmt.Sprintf(
-		"idem.Config{KeyHeader: %q, TTL: %v, StorageType: %s, LockSupported: %t, MetricsEnabled: %t}",
-		c.KeyHeader, c.TTL, c.StorageType, c.LockSupported, c.MetricsEnabled,
+		"idem.Config{KeyHeader: %q, TTL: %v, KeyMaxLength: %d, StorageType: %s, LockSupported: %t, MetricsEnabled: %t}",
+		c.KeyHeader, c.TTL, c.KeyMaxLength, c.StorageType, c.LockSupported, c.MetricsEnabled,
 	)
 }
 
@@ -117,8 +122,10 @@ func WithStorage(s Storage) Option {
 	}
 }
 
-// WithOnError specifies a callback function that is called when a storage operation fails.
-func WithOnError(fn func(error)) Option {
+// WithOnError specifies a callback function that is called when a storage
+// operation (Get or Set) fails. The key is the idempotency key from the request.
+// Lock contention is not reported here; use Metrics.OnLockContention instead.
+func WithOnError(fn func(key string, err error)) Option {
 	return func(c *config) {
 		c.onError = fn
 	}

--- a/option_test.go
+++ b/option_test.go
@@ -121,14 +121,14 @@ func TestWithOnError(t *testing.T) {
 	cfg := defaultConfig()
 
 	called := false
-	fn := func(_ error) { called = true }
+	fn := func(_ string, _ error) { called = true }
 	WithOnError(fn)(cfg)
 
 	if cfg.onError == nil {
 		t.Fatal("onError = nil, want non-nil")
 	}
 
-	cfg.onError(nil)
+	cfg.onError("test-key", nil)
 
 	if !called {
 		t.Error("callback was not called")
@@ -384,7 +384,7 @@ func TestConfig_snapshot(t *testing.T) {
 			t.Error("OnErrorEnabled = true without onError, want false")
 		}
 
-		WithOnError(func(_ error) {})(cfg)
+		WithOnError(func(_ string, _ error) {})(cfg)
 		if !cfg.snapshot().OnErrorEnabled {
 			t.Error("OnErrorEnabled = false with onError, want true")
 		}

--- a/redis/redis.go
+++ b/redis/redis.go
@@ -105,6 +105,13 @@ func (s *Storage) Get(ctx context.Context, key string) (*idem.Response, error) {
 		return nil, err
 	}
 
+	// StatusCode 0 is not a valid HTTP status. This guards against
+	// corrupt or legacy cache entries (e.g. serialized without JSON
+	// tags) where all fields decode to zero values.
+	if res.StatusCode == 0 {
+		return nil, nil
+	}
+
 	return &res, nil
 }
 

--- a/redis/redis_test.go
+++ b/redis/redis_test.go
@@ -112,7 +112,7 @@ func runStorageTests(t *testing.T, name string, factory clientFactory) {
 
 			want := &idem.Response{
 				StatusCode: http.StatusOK,
-				Header:     map[string][]string{"Content-Type": {"application/json"}},
+				Header:     http.Header{"Content-Type": {"application/json"}},
 				Body:       []byte(`{"ok":true}`),
 			}
 
@@ -130,9 +130,9 @@ func runStorageTests(t *testing.T, name string, factory clientFactory) {
 			if got.StatusCode != want.StatusCode {
 				t.Errorf("StatusCode = %d, want %d", got.StatusCode, want.StatusCode)
 			}
-			if http.Header(got.Header).Get("Content-Type") != http.Header(want.Header).Get("Content-Type") {
+			if got.Header.Get("Content-Type") != want.Header.Get("Content-Type") {
 				t.Errorf("Header Content-Type = %q, want %q",
-					http.Header(got.Header).Get("Content-Type"), http.Header(want.Header).Get("Content-Type"))
+					got.Header.Get("Content-Type"), want.Header.Get("Content-Type"))
 			}
 			if string(got.Body) != string(want.Body) {
 				t.Errorf("Body = %q, want %q", got.Body, want.Body)
@@ -190,7 +190,7 @@ func runStorageTests(t *testing.T, name string, factory clientFactory) {
 
 			res := &idem.Response{
 				StatusCode: http.StatusOK,
-				Header:     map[string][]string{"Content-Type": {"application/json"}},
+				Header:     http.Header{"Content-Type": {"application/json"}},
 				Body:       []byte(`{"ok":true}`),
 			}
 

--- a/response.go
+++ b/response.go
@@ -1,8 +1,10 @@
 package idem
 
+import "net/http"
+
 // Response represents a cached HTTP response.
 type Response struct {
-	StatusCode int
-	Header     map[string][]string
-	Body       []byte
+	StatusCode int         `json:"status_code"`
+	Header     http.Header `json:"header"`
+	Body       []byte      `json:"body"`
 }


### PR DESCRIPTION
## Summary
- Change `WithOnError` signature from `func(error)` to `func(key string, err error)` for consistency with `Metrics.OnError`
- Remove `onError` callback from lock contention path (lock contention is reported exclusively via `Metrics.OnLockContention`)
- Change `Response.Header` type from `map[string][]string` to `http.Header` for type safety and standard library consistency
- Add JSON tags (`snake_case`) to `Response` struct fields for consistency with `Config`
- Add `KeyMaxLength` field to `Config` snapshot and `Config.String()` output
- Add defensive `StatusCode==0` validation in `redis.Storage.Get()` to treat legacy/corrupt cache entries as cache misses
- Update all tests, examples (`redis-gin`, `nginx-redis-gin`, `redis-cluster-gin`, `redis-sentinel-gin`), and documentation (`README.md`, `CLAUDE.md`)

## Test plan
- [x] All unit tests pass (`make test-unit`: 164 tests, 31 integration skipped)
- [x] Lint passes (`make lint`: 0 issues)
- [x] All examples build successfully
- [ ] Integration tests pass in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)