### PR TITLE
Close #124: Prevent nil regexp panic in KeyHeaderPattern

### DIFF
--- a/validator.go
+++ b/validator.go
@@ -1,6 +1,7 @@
 package idem
 
 import (
+	"errors"
 	"fmt"
 	"regexp"
 	"time"
@@ -30,6 +31,9 @@ func MinTTL(limit time.Duration) Validator {
 // name to match the given regular expression pattern.
 func KeyHeaderPattern(pattern *regexp.Regexp) Validator {
 	return func(cfg Config) error {
+		if pattern == nil {
+			return errors.New("idem: key header pattern must not be nil")
+		}
 		if !pattern.MatchString(cfg.KeyHeader) {
 			return fmt.Errorf("idem: key header %q does not match pattern %s", cfg.KeyHeader, pattern)
 		}

--- a/validator_test.go
+++ b/validator_test.go
@@ -111,6 +111,11 @@ func TestKeyHeaderPattern(t *testing.T) {
 			keyHeader: "Idempotency-Key",
 			wantErr:   true,
 		},
+		{
+			name:    "nil pattern returns error",
+			pattern: nil,
+			wantErr: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -225,6 +230,17 @@ func TestNew_withPresetValidators(t *testing.T) {
 		_, err := New(
 			WithKeyHeader("X-Custom"),
 			WithValidation(AllowedKeyHeaders("Idempotency-Key", "X-Request-Id")),
+		)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+	})
+
+	t.Run("returns error when KeyHeaderPattern receives nil pattern", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := New(
+			WithValidation(KeyHeaderPattern(nil)),
 		)
 		if err == nil {
 			t.Fatal("expected error, got nil")


### PR DESCRIPTION
## Summary
- Add nil guard to `KeyHeaderPattern` validator to return an error instead of panicking when a nil `*regexp.Regexp` is passed
- Add unit test for nil pattern in `TestKeyHeaderPattern` table
- Add integration test for nil pattern via `New()` + `WithValidation` in `TestNew_withPresetValidators`

## Test plan
- [x] `TestKeyHeaderPattern/nil_pattern_returns_error` passes
- [x] `TestNew_withPresetValidators/returns_error_when_KeyHeaderPattern_receives_nil_pattern` passes
- [x] All existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)