### PR TITLE
Split release workflow into three event-driven workflows

### DIFF
--- a/.github/workflows/on-release-published.yml
+++ b/.github/workflows/on-release-published.yml
@@ -1,89 +1,14 @@
 name: on-release-published
 
 on:
-  workflow_dispatch:
-    inputs:
-      version:
-        description: "Release version (e.g. v1.2.3)"
-        required: true
-        type: string
+  release:
+    types:
+      - published
 
 permissions:
-  contents: write
   issues: write
 
 jobs:
-  validate:
-    name: Validate
-    runs-on: ubuntu-latest
-    steps:
-      - name: Validate version format
-        run: |
-          VERSION="${{ inputs.version }}"
-          if [[ ! "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$ ]]; then
-            echo "::error::Invalid version format: $VERSION"
-            echo "Expected format: v1.2.3 or v1.2.3-rc.1"
-            exit 1
-          fi
-
-      - name: Checkout
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-
-      - name: Check tag does not already exist
-        run: |
-          if git rev-parse "${{ inputs.version }}" >/dev/null 2>&1; then
-            echo "::error::Tag ${{ inputs.version }} already exists"
-            exit 1
-          fi
-
-  push-and-request-index:
-    name: Tag & Index
-    needs: validate
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Setup Go
-        uses: actions/setup-go@v6
-        with:
-          go-version-file: go.mod
-
-      - name: Create and push tag
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git tag -a "${{ inputs.version }}" -m "Release ${{ inputs.version }}"
-          git push origin "${{ inputs.version }}"
-
-      - name: Index on pkg.go.dev
-        run: |
-          MODULE=$(go list -m)
-          VERSION="${{ inputs.version }}"
-          echo "Requesting index for ${MODULE}@${VERSION}"
-          GOPROXY=https://proxy.golang.org go list -m "${MODULE}@${VERSION}"
-
-  release:
-    name: GitHub Release
-    needs: push-and-request-index
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-
-      - name: Create GitHub Release
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh release create "${{ inputs.version }}" \
-            --title "${{ inputs.version }}" \
-            --generate-notes \
-            --target "${{ inputs.version }}"
-
   close-milestone:
     name: Close Milestone
     runs-on: ubuntu-latest

--- a/.github/workflows/on-tag-push.yml
+++ b/.github/workflows/on-tag-push.yml
@@ -1,0 +1,47 @@
+name: on-tag-push
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  request-index:
+    name: Index on pkg.go.dev
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+
+      - name: Index on pkg.go.dev
+        run: |
+          MODULE=$(go list -m)
+          VERSION="${GITHUB_REF_NAME}"
+          echo "Requesting index for ${MODULE}@${VERSION}"
+          GOPROXY=https://proxy.golang.org go list -m "${MODULE}@${VERSION}"
+
+  release:
+    name: GitHub Release
+    needs: request-index
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "${GITHUB_REF_NAME}" \
+            --title "${GITHUB_REF_NAME}" \
+            --generate-notes

--- a/.github/workflows/on-workflow-dispatch.yml
+++ b/.github/workflows/on-workflow-dispatch.yml
@@ -1,0 +1,53 @@
+name: on-workflow-dispatch
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Release version (e.g. v1.2.3)"
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  validate:
+    name: Validate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate version format
+        run: |
+          VERSION="${{ inputs.version }}"
+          if [[ ! "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$ ]]; then
+            echo "::error::Invalid version format: $VERSION"
+            echo "Expected format: v1.2.3 or v1.2.3-rc.1"
+            exit 1
+          fi
+
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Check tag does not already exist
+        run: |
+          if git rev-parse "${{ inputs.version }}" >/dev/null 2>&1; then
+            echo "::error::Tag ${{ inputs.version }} already exists"
+            exit 1
+          fi
+
+  push-tag:
+    name: Push Tag
+    needs: validate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Create and push tag
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -a "${{ inputs.version }}" -m "Release ${{ inputs.version }}"
+          git push origin "${{ inputs.version }}"


### PR DESCRIPTION
## Summary
- **on-workflow-dispatch**: バージョンバリデーション → タグ作成・Push のみに縮小
- **on-tag-push**: `v*` タグPushで発火し、pkg.go.dev へのインデックス登録と GitHub Release 作成を実行
- **on-release-published**: リリース公開イベントで発火し、同名マイルストーンをクローズ

## Test plan
- [ ] `workflow_dispatch` でバージョンを指定してタグがPushされることを確認
- [ ] タグPush後に `on-tag-push` が発火し、Release が作成されることを確認
- [ ] Release 作成後に `on-release-published` が発火し、マイルストーンがクローズされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)