### PR TITLE
Use PAT user for tag push to trigger downstream workflows

### DIFF
--- a/.github/workflows/on-workflow-dispatch.yml
+++ b/.github/workflows/on-workflow-dispatch.yml
@@ -44,10 +44,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          token: ${{ secrets.AUTH_TOKEN }}
 
       - name: Create and push tag
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config user.name "${{ secrets.BR_GITHUB_MANAGER_NAME }}"
+          git config user.email "${{ secrets.BR_GITHUB_MANAGER_EMAIL }}"
           git tag -a "${{ inputs.version }}" -m "Release ${{ inputs.version }}"
           git push origin "${{ inputs.version }}"


### PR DESCRIPTION
## Summary
- `on-workflow-dispatch.yml` のタグpush時の認証を `GITHUB_TOKEN`（github-actions[bot]）から br-github-manager の PAT に変更
- `GITHUB_TOKEN` によるpushは後続ワークフロー（`on-push-tag`）のトリガーが抑制されるため、PATユーザーでの認証が必要

## Required Secrets
- `AUTH_TOKEN` — br-github-manager の Personal Access Token
- `BR_GITHUB_MANAGER_NAME` — ユーザー名
- `BR_GITHUB_MANAGER_EMAIL` — メールアドレス

## Test plan
- [ ] リポジトリシークレットに上記3つが設定されていることを確認
- [ ] workflow_dispatch でタグを作成し、後続の on-push-tag ワークフローが正常にトリガーされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)