### PR TITLE
Close #137: Export sentinel errors for programmatic error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,28 @@ http.HandleFunc("/debug/idem/config", func(w http.ResponseWriter, r *http.Reques
 
 The `Config` struct includes JSON tags and implements `fmt.Stringer` for convenient serialization.
 
+## Error Handling
+
+`New` returns sentinel errors for invalid configuration, so callers can identify specific error conditions programmatically using `errors.Is`:
+
+```go
+_, err := idem.New(idem.WithKeyHeader(""))
+if errors.Is(err, idem.ErrEmptyKeyHeader) {
+	// handle empty key header
+}
+```
+
+### Sentinel Errors
+
+| Package | Error | Condition |
+|---------|-------|-----------|
+| `idem` | `ErrEmptyKeyHeader` | Key header is empty |
+| `idem` | `ErrInvalidTTL` | TTL is zero or negative |
+| `idem` | `ErrNilKeyHeaderPattern` | `KeyHeaderPattern` receives a nil regexp |
+| `idem/redis` | `ErrNilClient` | Redis client is nil |
+| `idem/redis` | `ErrEmptyKeyPrefix` | Key prefix is empty |
+| `idem/redis` | `ErrEmptyLockPrefix` | Lock prefix is empty |
+
 ## How It Works
 
 ```

--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,16 @@
+package idem
+
+import "errors"
+
+// Sentinel errors returned by New when the configuration is invalid.
+var (
+	// ErrEmptyKeyHeader is returned when the keyHeader is empty.
+	ErrEmptyKeyHeader = errors.New("idem: keyHeader must not be empty")
+
+	// ErrInvalidTTL is returned when the TTL is zero or negative.
+	ErrInvalidTTL = errors.New("idem: ttl must be positive")
+
+	// ErrNilKeyHeaderPattern is returned by KeyHeaderPattern when the
+	// pattern argument is nil.
+	ErrNilKeyHeaderPattern = errors.New("idem: key header pattern must not be nil")
+)

--- a/errors_test.go
+++ b/errors_test.go
@@ -1,0 +1,39 @@
+package idem_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/bright-room/idem"
+)
+
+func TestNew_sentinelErrors(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns ErrEmptyKeyHeader for empty key header", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := idem.New(idem.WithKeyHeader(""))
+		if !errors.Is(err, idem.ErrEmptyKeyHeader) {
+			t.Errorf("error = %v, want %v", err, idem.ErrEmptyKeyHeader)
+		}
+	})
+
+	t.Run("returns ErrInvalidTTL for zero TTL", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := idem.New(idem.WithTTL(0))
+		if !errors.Is(err, idem.ErrInvalidTTL) {
+			t.Errorf("error = %v, want %v", err, idem.ErrInvalidTTL)
+		}
+	})
+
+	t.Run("returns ErrNilKeyHeaderPattern for nil pattern", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := idem.New(idem.WithValidation(idem.KeyHeaderPattern(nil)))
+		if !errors.Is(err, idem.ErrNilKeyHeaderPattern) {
+			t.Errorf("error = %v, want %v", err, idem.ErrNilKeyHeaderPattern)
+		}
+	})
+}

--- a/option.go
+++ b/option.go
@@ -1,7 +1,6 @@
 package idem
 
 import (
-	"errors"
 	"fmt"
 	"time"
 )
@@ -153,11 +152,11 @@ func WithValidation(validators ...Validator) Option {
 // validate checks the config for invalid values.
 func (c *config) validate() error {
 	if c.keyHeader == "" {
-		return errors.New("idem: keyHeader must not be empty")
+		return ErrEmptyKeyHeader
 	}
 
 	if c.ttl <= 0 {
-		return errors.New("idem: ttl must be positive")
+		return ErrInvalidTTL
 	}
 
 	snap := c.snapshot()

--- a/redis/errors.go
+++ b/redis/errors.go
@@ -1,0 +1,15 @@
+package redis
+
+import "errors"
+
+// Sentinel errors returned by New when the configuration is invalid.
+var (
+	// ErrNilClient is returned when the Redis client is nil.
+	ErrNilClient = errors.New("redis: client must not be nil")
+
+	// ErrEmptyKeyPrefix is returned when the key prefix is empty.
+	ErrEmptyKeyPrefix = errors.New("redis: keyPrefix must not be empty")
+
+	// ErrEmptyLockPrefix is returned when the lock prefix is empty.
+	ErrEmptyLockPrefix = errors.New("redis: lockPrefix must not be empty")
+)

--- a/redis/errors_test.go
+++ b/redis/errors_test.go
@@ -1,0 +1,43 @@
+package redis_test
+
+import (
+	"errors"
+	"testing"
+
+	iredis "github.com/bright-room/idem/redis"
+	goredis "github.com/redis/go-redis/v9"
+)
+
+func TestNew_sentinelErrors(t *testing.T) {
+	t.Parallel()
+
+	// stub client for validation-only tests (no actual Redis connection needed)
+	stub := goredis.NewClient(&goredis.Options{})
+
+	t.Run("returns ErrNilClient for nil client", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := iredis.New(nil)
+		if !errors.Is(err, iredis.ErrNilClient) {
+			t.Errorf("error = %v, want %v", err, iredis.ErrNilClient)
+		}
+	})
+
+	t.Run("returns ErrEmptyKeyPrefix for empty key prefix", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := iredis.New(stub, iredis.WithKeyPrefix(""))
+		if !errors.Is(err, iredis.ErrEmptyKeyPrefix) {
+			t.Errorf("error = %v, want %v", err, iredis.ErrEmptyKeyPrefix)
+		}
+	})
+
+	t.Run("returns ErrEmptyLockPrefix for empty lock prefix", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := iredis.New(stub, iredis.WithLockPrefix(""))
+		if !errors.Is(err, iredis.ErrEmptyLockPrefix) {
+			t.Errorf("error = %v, want %v", err, iredis.ErrEmptyLockPrefix)
+		}
+	})
+}

--- a/redis/redis.go
+++ b/redis/redis.go
@@ -75,15 +75,15 @@ func New(client goredis.Cmdable, opts ...Option) (*Storage, error) {
 // validate checks the Storage configuration for invalid values.
 func (s *Storage) validate() error {
 	if s.client == nil {
-		return errors.New("redis: client must not be nil")
+		return ErrNilClient
 	}
 
 	if s.keyPrefix == "" {
-		return errors.New("redis: keyPrefix must not be empty")
+		return ErrEmptyKeyPrefix
 	}
 
 	if s.lockPrefix == "" {
-		return errors.New("redis: lockPrefix must not be empty")
+		return ErrEmptyLockPrefix
 	}
 
 	return nil

--- a/validator.go
+++ b/validator.go
@@ -1,7 +1,6 @@
 package idem
 
 import (
-	"errors"
 	"fmt"
 	"regexp"
 	"time"
@@ -32,7 +31,7 @@ func MinTTL(limit time.Duration) Validator {
 func KeyHeaderPattern(pattern *regexp.Regexp) Validator {
 	return func(cfg Config) error {
 		if pattern == nil {
-			return errors.New("idem: key header pattern must not be nil")
+			return ErrNilKeyHeaderPattern
 		}
 		if !pattern.MatchString(cfg.KeyHeader) {
 			return fmt.Errorf("idem: key header %q does not match pattern %s", cfg.KeyHeader, pattern)


### PR DESCRIPTION
## Summary
- Add exported sentinel error variables (`ErrEmptyKeyHeader`, `ErrInvalidTTL`, `ErrNilKeyHeaderPattern`) in the root `idem` package
- Add exported sentinel error variables (`ErrNilClient`, `ErrEmptyKeyPrefix`, `ErrEmptyLockPrefix`) in the `redis` package
- Replace `errors.New()` calls in `option.go`, `validator.go`, and `redis/redis.go` with sentinel error references
- Add `errors.Is()` tests in `errors_test.go` and `redis/errors_test.go`
- Add Error Handling section to README with usage examples and sentinel error table

## Test plan
- [x] `errors.Is()` correctly identifies `ErrEmptyKeyHeader` from `idem.New(WithKeyHeader(""))`
- [x] `errors.Is()` correctly identifies `ErrInvalidTTL` from `idem.New(WithTTL(0))`
- [x] `errors.Is()` correctly identifies `ErrNilKeyHeaderPattern` from `KeyHeaderPattern(nil)`
- [x] `errors.Is()` correctly identifies `ErrNilClient` from `redis.New(nil)`
- [x] `errors.Is()` correctly identifies `ErrEmptyKeyPrefix` from `redis.New(stub, WithKeyPrefix(""))`
- [x] `errors.Is()` correctly identifies `ErrEmptyLockPrefix` from `redis.New(stub, WithLockPrefix(""))`
- [x] Existing tests pass without modification

🤖 Generated with [Claude Code](https://claude.com/claude-code)