### PR TITLE
Close #94: Add TTLRange validator

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ Common validation rules are available as factory functions:
 |-----------|-------------|
 | `MaxTTL(max)` | Rejects a TTL longer than `max` |
 | `MinTTL(min)` | Rejects a TTL shorter than `min` |
+| `TTLRange(min, max)` | Rejects a TTL outside the `[min, max]` range |
 | `KeyHeaderPattern(re)` | Requires the key header name to match the regular expression |
 | `AllowedKeyHeaders(h...)` | Requires the key header name to be one of the allowed values |
 

--- a/errors.go
+++ b/errors.go
@@ -13,4 +13,7 @@ var (
 	// ErrNilKeyHeaderPattern is returned by KeyHeaderPattern when the
 	// pattern argument is nil.
 	ErrNilKeyHeaderPattern = errors.New("idem: key header pattern must not be nil")
+
+	// ErrInvalidTTLRange is returned by TTLRange when min exceeds max.
+	ErrInvalidTTLRange = errors.New("idem: TTLRange min must not exceed max")
 )

--- a/validator.go
+++ b/validator.go
@@ -26,6 +26,19 @@ func MinTTL(limit time.Duration) Validator {
 	}
 }
 
+// TTLRange returns a Validator that rejects a TTL outside the [lower, upper] range.
+func TTLRange(lower, upper time.Duration) Validator {
+	return func(cfg Config) error {
+		if lower > upper {
+			return ErrInvalidTTLRange
+		}
+		if cfg.TTL < lower || cfg.TTL > upper {
+			return fmt.Errorf("idem: ttl %v is out of range [%v, %v]", cfg.TTL, lower, upper)
+		}
+		return nil
+	}
+}
+
 // KeyHeaderPattern returns a Validator that requires the key header
 // name to match the given regular expression pattern.
 func KeyHeaderPattern(pattern *regexp.Regexp) Validator {

--- a/validator_test.go
+++ b/validator_test.go
@@ -1,6 +1,7 @@
 package idem
 
 import (
+	"errors"
 	"regexp"
 	"testing"
 	"time"
@@ -85,6 +86,92 @@ func TestMinTTL(t *testing.T) {
 			err := v(Config{KeyHeader: DefaultKeyHeader, TTL: tt.ttl})
 			if (err != nil) != tt.wantErr {
 				t.Errorf("MinTTL(%v)() error = %v, wantErr %v", tt.min, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestTTLRange(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		min          time.Duration
+		max          time.Duration
+		ttl          time.Duration
+		wantErr      bool
+		wantSentinel error
+	}{
+		{
+			name:    "exactly at minimum",
+			min:     1 * time.Minute,
+			max:     24 * time.Hour,
+			ttl:     1 * time.Minute,
+			wantErr: false,
+		},
+		{
+			name:    "exactly at maximum",
+			min:     1 * time.Minute,
+			max:     24 * time.Hour,
+			ttl:     24 * time.Hour,
+			wantErr: false,
+		},
+		{
+			name:    "within range",
+			min:     1 * time.Minute,
+			max:     24 * time.Hour,
+			ttl:     1 * time.Hour,
+			wantErr: false,
+		},
+		{
+			name:    "below minimum",
+			min:     1 * time.Minute,
+			max:     24 * time.Hour,
+			ttl:     30 * time.Second,
+			wantErr: true,
+		},
+		{
+			name:    "exceeds maximum",
+			min:     1 * time.Minute,
+			max:     24 * time.Hour,
+			ttl:     48 * time.Hour,
+			wantErr: true,
+		},
+		{
+			name:    "min equals max and TTL matches",
+			min:     1 * time.Hour,
+			max:     1 * time.Hour,
+			ttl:     1 * time.Hour,
+			wantErr: false,
+		},
+		{
+			name:    "min equals max and TTL does not match",
+			min:     1 * time.Hour,
+			max:     1 * time.Hour,
+			ttl:     2 * time.Hour,
+			wantErr: true,
+		},
+		{
+			name:         "min exceeds max",
+			min:          24 * time.Hour,
+			max:          1 * time.Minute,
+			ttl:          1 * time.Hour,
+			wantErr:      true,
+			wantSentinel: ErrInvalidTTLRange,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			v := TTLRange(tt.min, tt.max)
+			err := v(Config{KeyHeader: DefaultKeyHeader, TTL: tt.ttl})
+			if (err != nil) != tt.wantErr {
+				t.Errorf("TTLRange(%v, %v)() error = %v, wantErr %v", tt.min, tt.max, err, tt.wantErr)
+			}
+			if tt.wantSentinel != nil && !errors.Is(err, tt.wantSentinel) {
+				t.Errorf("TTLRange(%v, %v)() error = %v, want %v", tt.min, tt.max, err, tt.wantSentinel)
 			}
 		})
 	}
@@ -241,6 +328,33 @@ func TestNew_withPresetValidators(t *testing.T) {
 
 		_, err := New(
 			WithValidation(KeyHeaderPattern(nil)),
+		)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+	})
+
+	t.Run("succeeds when TTLRange passes", func(t *testing.T) {
+		t.Parallel()
+
+		m, err := New(
+			WithTTL(1*time.Hour),
+			WithValidation(TTLRange(1*time.Minute, 24*time.Hour)),
+		)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if m == nil {
+			t.Fatal("middleware is nil")
+		}
+	})
+
+	t.Run("returns error when TTLRange fails", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := New(
+			WithTTL(48*time.Hour),
+			WithValidation(TTLRange(1*time.Minute, 24*time.Hour)),
 		)
 		if err == nil {
 			t.Fatal("expected error, got nil")


### PR DESCRIPTION
## Summary
- Add `TTLRange(lower, upper)` validator that rejects a TTL outside the `[lower, upper]` range
- Add `ErrInvalidTTLRange` sentinel error for when `lower > upper`
- Add comprehensive table-driven tests including boundary values and `min > max` case
- Add `TTLRange` subtests to `TestNew_withPresetValidators`
- Update README validator table with `TTLRange`

## Test plan
- [x] Unit tests for `TTLRange` (boundary values, within range, out of range, min==max, min>max)
- [x] Integration tests with `New` + `TTLRange` (success and failure cases)
- [x] All existing tests pass
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)