### PR TITLE
Close #95: Add WithMessage support for preset validators

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,7 @@ make shell          # Interactive bash in container
 Key interfaces:
 - `Storage` — `Get`/`Set`/`Delete` for cached responses (pluggable backend)
 - `Locker` — optional per-key mutual exclusion for concurrent request handling. Storage implementations that also implement `Locker` enable automatic lock acquisition in the middleware. Returns 409 Conflict on lock failure.
+- `Validator` — `Validate(Config) error` for configuration validation. `ValidatorFunc` is a function adapter (like `http.HandlerFunc`). Preset validators (`MaxTTL`, `MinTTL`, etc.) return `*PresetValidator` which supports `.WithMessage()` for custom error messages.
 
 Configuration uses the **Functional Options** pattern (`WithXxx()` functions).
 

--- a/README.md
+++ b/README.md
@@ -92,12 +92,12 @@ Use `WithValidation` to enforce application-specific rules on the middleware con
 ```go
 mw, err := idem.New(
 	idem.WithTTL(30 * time.Minute),
-	idem.WithValidation(func(cfg idem.Config) error {
+	idem.WithValidation(idem.ValidatorFunc(func(cfg idem.Config) error {
 		if cfg.TTL > 1*time.Hour {
 			return fmt.Errorf("TTL must not exceed 1 hour, got %v", cfg.TTL)
 		}
 		return nil
-	}),
+	})),
 )
 ```
 
@@ -122,6 +122,18 @@ mw, err := idem.New(
 		idem.MaxTTL(24 * time.Hour),
 		idem.MinTTL(1 * time.Minute),
 		idem.AllowedKeyHeaders("Idempotency-Key", "X-Request-Id"),
+	),
+)
+```
+
+Preset validators support custom error messages via `WithMessage`:
+
+```go
+mw, err := idem.New(
+	idem.WithTTL(1 * time.Hour),
+	idem.WithValidation(
+		idem.MaxTTL(24 * time.Hour).WithMessage("TTL is too long for this service"),
+		idem.MinTTL(1 * time.Minute).WithMessage("TTL is too short"),
 	),
 )
 ```

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -795,7 +795,7 @@ func TestMiddleware_Config(t *testing.T) {
 			WithStorage(&stubStorage{}),
 			WithOnError(func(_ string, _ error) {}),
 			WithMetrics(Metrics{}),
-			WithValidation(func(_ Config) error { return nil }),
+			WithValidation(ValidatorFunc(func(_ Config) error { return nil })),
 		)
 		cfg := mw.Config()
 

--- a/option.go
+++ b/option.go
@@ -46,9 +46,21 @@ type Config struct {
 	ValidatorCount int `json:"validator_count"`
 }
 
-// Validator is a function that inspects the middleware configuration and
-// returns an error if it does not meet application-specific requirements.
-type Validator func(Config) error
+// Validator inspects the middleware configuration and returns an error
+// if it does not meet application-specific requirements.
+type Validator interface {
+	Validate(Config) error
+}
+
+// ValidatorFunc is an adapter to allow the use of ordinary functions as Validators.
+// If f is a function with the appropriate signature, ValidatorFunc(f) is a Validator
+// that calls f.
+type ValidatorFunc func(Config) error
+
+// Validate calls f(cfg).
+func (f ValidatorFunc) Validate(cfg Config) error {
+	return f(cfg)
+}
 
 type config struct {
 	keyHeader    string
@@ -161,7 +173,7 @@ func (c *config) validate() error {
 
 	snap := c.snapshot()
 	for _, v := range c.validators {
-		if err := v(snap); err != nil {
+		if err := v.Validate(snap); err != nil {
 			return err
 		}
 	}

--- a/option_test.go
+++ b/option_test.go
@@ -184,9 +184,9 @@ func TestConfig_validate(t *testing.T) {
 			name: "custom validator passes",
 			cfg: func() *config {
 				c := defaultConfig()
-				WithValidation(func(_ Config) error {
+				WithValidation(ValidatorFunc(func(_ Config) error {
 					return nil
-				})(c)
+				}))(c)
 				return c
 			}(),
 			wantErr: false,
@@ -195,9 +195,9 @@ func TestConfig_validate(t *testing.T) {
 			name: "custom validator fails",
 			cfg: func() *config {
 				c := defaultConfig()
-				WithValidation(func(_ Config) error {
+				WithValidation(ValidatorFunc(func(_ Config) error {
 					return errors.New("custom: validation failed")
-				})(c)
+				}))(c)
 				return c
 			}(),
 			wantErr: true,
@@ -208,14 +208,14 @@ func TestConfig_validate(t *testing.T) {
 				c := defaultConfig()
 				second := false
 				WithValidation(
-					func(_ Config) error {
+					ValidatorFunc(func(_ Config) error {
 						return errors.New("first fails")
-					},
-					func(_ Config) error {
+					}),
+					ValidatorFunc(func(_ Config) error {
 						second = true
 						_ = second
 						return nil
-					},
+					}),
 				)(c)
 				return c
 			}(),
@@ -228,7 +228,7 @@ func TestConfig_validate(t *testing.T) {
 					keyHeader: "X-Test",
 					ttl:       5 * time.Minute,
 				}
-				WithValidation(func(cfg Config) error {
+				WithValidation(ValidatorFunc(func(cfg Config) error {
 					if cfg.KeyHeader != "X-Test" {
 						return errors.New("unexpected KeyHeader")
 					}
@@ -236,7 +236,7 @@ func TestConfig_validate(t *testing.T) {
 						return errors.New("unexpected TTL")
 					}
 					return nil
-				})(c)
+				}))(c)
 				return c
 			}(),
 			wantErr: false,
@@ -248,9 +248,9 @@ func TestConfig_validate(t *testing.T) {
 					keyHeader: "",
 					ttl:       DefaultTTL,
 				}
-				WithValidation(func(_ Config) error {
+				WithValidation(ValidatorFunc(func(_ Config) error {
 					return errors.New("should not reach here")
-				})(c)
+				}))(c)
 				return c
 			}(),
 			wantErr: true,
@@ -275,17 +275,17 @@ func TestWithValidation(t *testing.T) {
 	cfg := defaultConfig()
 
 	called := false
-	v := func(_ Config) error {
+	v := ValidatorFunc(func(_ Config) error {
 		called = true
 		return nil
-	}
+	})
 	WithValidation(v)(cfg)
 
 	if len(cfg.validators) != 1 {
 		t.Fatalf("validators length = %d, want 1", len(cfg.validators))
 	}
 
-	if err := cfg.validators[0](cfg.snapshot()); err != nil {
+	if err := cfg.validators[0].Validate(cfg.snapshot()); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
@@ -399,8 +399,8 @@ func TestConfig_snapshot(t *testing.T) {
 		}
 
 		WithValidation(
-			func(_ Config) error { return nil },
-			func(_ Config) error { return nil },
+			ValidatorFunc(func(_ Config) error { return nil }),
+			ValidatorFunc(func(_ Config) error { return nil }),
 		)(cfg)
 
 		if cfg.snapshot().ValidatorCount != 2 {
@@ -445,9 +445,9 @@ func TestNew_withCustomValidation(t *testing.T) {
 	t.Run("returns error from custom validator", func(t *testing.T) {
 		t.Parallel()
 
-		_, err := New(WithValidation(func(_ Config) error {
+		_, err := New(WithValidation(ValidatorFunc(func(_ Config) error {
 			return errors.New("custom: not allowed")
-		}))
+		})))
 		if err == nil {
 			t.Fatal("expected error, got nil")
 		}
@@ -456,9 +456,9 @@ func TestNew_withCustomValidation(t *testing.T) {
 	t.Run("succeeds with passing custom validator", func(t *testing.T) {
 		t.Parallel()
 
-		m, err := New(WithValidation(func(_ Config) error {
+		m, err := New(WithValidation(ValidatorFunc(func(_ Config) error {
 			return nil
-		}))
+		})))
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}

--- a/validator.go
+++ b/validator.go
@@ -1,67 +1,108 @@
 package idem
 
 import (
+	"errors"
 	"fmt"
 	"regexp"
 	"time"
 )
 
-// MaxTTL returns a Validator that rejects a TTL longer than max.
-func MaxTTL(limit time.Duration) Validator {
-	return func(cfg Config) error {
-		if cfg.TTL > limit {
-			return fmt.Errorf("idem: ttl %v exceeds maximum %v", cfg.TTL, limit)
+// PresetValidator is a Validator returned by the built-in validator
+// constructors (MaxTTL, MinTTL, etc.). It supports custom error messages
+// via the WithMessage method.
+type PresetValidator struct {
+	validate func(Config) error
+	msg      string
+}
+
+// Validate runs the validation logic. If a custom message has been set via
+// WithMessage and the underlying check fails, the custom message is returned
+// instead of the default error.
+func (p *PresetValidator) Validate(cfg Config) error {
+	if err := p.validate(cfg); err != nil {
+		if p.msg != "" {
+			return errors.New(p.msg)
 		}
-		return nil
+		return err
+	}
+	return nil
+}
+
+// WithMessage returns a copy of the PresetValidator that uses msg as the
+// error message when validation fails.
+func (p *PresetValidator) WithMessage(msg string) *PresetValidator {
+	return &PresetValidator{
+		validate: p.validate,
+		msg:      msg,
+	}
+}
+
+// MaxTTL returns a Validator that rejects a TTL longer than max.
+func MaxTTL(limit time.Duration) *PresetValidator {
+	return &PresetValidator{
+		validate: func(cfg Config) error {
+			if cfg.TTL > limit {
+				return fmt.Errorf("idem: ttl %v exceeds maximum %v", cfg.TTL, limit)
+			}
+			return nil
+		},
 	}
 }
 
 // MinTTL returns a Validator that rejects a TTL shorter than min.
-func MinTTL(limit time.Duration) Validator {
-	return func(cfg Config) error {
-		if cfg.TTL < limit {
-			return fmt.Errorf("idem: ttl %v is shorter than minimum %v", cfg.TTL, limit)
-		}
-		return nil
+func MinTTL(limit time.Duration) *PresetValidator {
+	return &PresetValidator{
+		validate: func(cfg Config) error {
+			if cfg.TTL < limit {
+				return fmt.Errorf("idem: ttl %v is shorter than minimum %v", cfg.TTL, limit)
+			}
+			return nil
+		},
 	}
 }
 
 // TTLRange returns a Validator that rejects a TTL outside the [lower, upper] range.
-func TTLRange(lower, upper time.Duration) Validator {
-	return func(cfg Config) error {
-		if lower > upper {
-			return ErrInvalidTTLRange
-		}
-		if cfg.TTL < lower || cfg.TTL > upper {
-			return fmt.Errorf("idem: ttl %v is out of range [%v, %v]", cfg.TTL, lower, upper)
-		}
-		return nil
+func TTLRange(lower, upper time.Duration) *PresetValidator {
+	return &PresetValidator{
+		validate: func(cfg Config) error {
+			if lower > upper {
+				return ErrInvalidTTLRange
+			}
+			if cfg.TTL < lower || cfg.TTL > upper {
+				return fmt.Errorf("idem: ttl %v is out of range [%v, %v]", cfg.TTL, lower, upper)
+			}
+			return nil
+		},
 	}
 }
 
 // KeyHeaderPattern returns a Validator that requires the key header
 // name to match the given regular expression pattern.
-func KeyHeaderPattern(pattern *regexp.Regexp) Validator {
-	return func(cfg Config) error {
-		if pattern == nil {
-			return ErrNilKeyHeaderPattern
-		}
-		if !pattern.MatchString(cfg.KeyHeader) {
-			return fmt.Errorf("idem: key header %q does not match pattern %s", cfg.KeyHeader, pattern)
-		}
-		return nil
+func KeyHeaderPattern(pattern *regexp.Regexp) *PresetValidator {
+	return &PresetValidator{
+		validate: func(cfg Config) error {
+			if pattern == nil {
+				return ErrNilKeyHeaderPattern
+			}
+			if !pattern.MatchString(cfg.KeyHeader) {
+				return fmt.Errorf("idem: key header %q does not match pattern %s", cfg.KeyHeader, pattern)
+			}
+			return nil
+		},
 	}
 }
 
 // AllowedKeyHeaders returns a Validator that requires the key header
 // name to be one of the specified allowed values.
-func AllowedKeyHeaders(allowed ...string) Validator {
-	return func(cfg Config) error {
-		for _, a := range allowed {
-			if cfg.KeyHeader == a {
-				return nil
+func AllowedKeyHeaders(allowed ...string) *PresetValidator {
+	return &PresetValidator{
+		validate: func(cfg Config) error {
+			for _, a := range allowed {
+				if cfg.KeyHeader == a {
+					return nil
+				}
 			}
-		}
-		return fmt.Errorf("idem: key header %q is not in allowed list %v", cfg.KeyHeader, allowed)
+			return fmt.Errorf("idem: key header %q is not in allowed list %v", cfg.KeyHeader, allowed)
+		},
 	}
 }

--- a/validator_test.go
+++ b/validator_test.go
@@ -41,7 +41,7 @@ func TestMaxTTL(t *testing.T) {
 			t.Parallel()
 
 			v := MaxTTL(tt.max)
-			err := v(Config{KeyHeader: DefaultKeyHeader, TTL: tt.ttl})
+			err := v.Validate(Config{KeyHeader: DefaultKeyHeader, TTL: tt.ttl})
 			if (err != nil) != tt.wantErr {
 				t.Errorf("MaxTTL(%v)() error = %v, wantErr %v", tt.max, err, tt.wantErr)
 			}
@@ -83,7 +83,7 @@ func TestMinTTL(t *testing.T) {
 			t.Parallel()
 
 			v := MinTTL(tt.min)
-			err := v(Config{KeyHeader: DefaultKeyHeader, TTL: tt.ttl})
+			err := v.Validate(Config{KeyHeader: DefaultKeyHeader, TTL: tt.ttl})
 			if (err != nil) != tt.wantErr {
 				t.Errorf("MinTTL(%v)() error = %v, wantErr %v", tt.min, err, tt.wantErr)
 			}
@@ -166,7 +166,7 @@ func TestTTLRange(t *testing.T) {
 			t.Parallel()
 
 			v := TTLRange(tt.min, tt.max)
-			err := v(Config{KeyHeader: DefaultKeyHeader, TTL: tt.ttl})
+			err := v.Validate(Config{KeyHeader: DefaultKeyHeader, TTL: tt.ttl})
 			if (err != nil) != tt.wantErr {
 				t.Errorf("TTLRange(%v, %v)() error = %v, wantErr %v", tt.min, tt.max, err, tt.wantErr)
 			}
@@ -210,7 +210,7 @@ func TestKeyHeaderPattern(t *testing.T) {
 			t.Parallel()
 
 			v := KeyHeaderPattern(tt.pattern)
-			err := v(Config{KeyHeader: tt.keyHeader, TTL: DefaultTTL})
+			err := v.Validate(Config{KeyHeader: tt.keyHeader, TTL: DefaultTTL})
 			if (err != nil) != tt.wantErr {
 				t.Errorf("KeyHeaderPattern(%s)() error = %v, wantErr %v", tt.pattern, err, tt.wantErr)
 			}
@@ -258,7 +258,7 @@ func TestAllowedKeyHeaders(t *testing.T) {
 			t.Parallel()
 
 			v := AllowedKeyHeaders(tt.allowed...)
-			err := v(Config{KeyHeader: tt.keyHeader, TTL: DefaultTTL})
+			err := v.Validate(Config{KeyHeader: tt.keyHeader, TTL: DefaultTTL})
 			if (err != nil) != tt.wantErr {
 				t.Errorf("AllowedKeyHeaders(%v)() error = %v, wantErr %v", tt.allowed, err, tt.wantErr)
 			}
@@ -372,6 +372,134 @@ func TestNew_withPresetValidators(t *testing.T) {
 				MinTTL(1*time.Minute),
 				AllowedKeyHeaders("Idempotency-Key", "X-Request-Id"),
 			),
+		)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if m == nil {
+			t.Fatal("middleware is nil")
+		}
+	})
+}
+
+func TestPresetValidator_WithMessage(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		v       *PresetValidator
+		cfg     Config
+		wantMsg string
+	}{
+		{
+			name:    "MaxTTL with custom message",
+			v:       MaxTTL(1 * time.Hour).WithMessage("TTL is too long for this service"),
+			cfg:     Config{TTL: 2 * time.Hour},
+			wantMsg: "TTL is too long for this service",
+		},
+		{
+			name:    "MinTTL with custom message",
+			v:       MinTTL(1 * time.Hour).WithMessage("TTL is too short"),
+			cfg:     Config{TTL: 30 * time.Minute},
+			wantMsg: "TTL is too short",
+		},
+		{
+			name:    "TTLRange with custom message",
+			v:       TTLRange(1*time.Minute, 1*time.Hour).WithMessage("TTL out of acceptable range"),
+			cfg:     Config{TTL: 2 * time.Hour},
+			wantMsg: "TTL out of acceptable range",
+		},
+		{
+			name:    "KeyHeaderPattern with custom message",
+			v:       KeyHeaderPattern(regexp.MustCompile(`^X-`)).WithMessage("header must start with X-"),
+			cfg:     Config{KeyHeader: "Idempotency-Key", TTL: DefaultTTL},
+			wantMsg: "header must start with X-",
+		},
+		{
+			name:    "AllowedKeyHeaders with custom message",
+			v:       AllowedKeyHeaders("Idempotency-Key").WithMessage("unsupported header"),
+			cfg:     Config{KeyHeader: "X-Custom", TTL: DefaultTTL},
+			wantMsg: "unsupported header",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := tt.v.Validate(tt.cfg)
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if err.Error() != tt.wantMsg {
+				t.Errorf("error = %q, want %q", err.Error(), tt.wantMsg)
+			}
+		})
+	}
+}
+
+func TestPresetValidator_WithMessage_defaultMessageWithoutWithMessage(t *testing.T) {
+	t.Parallel()
+
+	v := MaxTTL(1 * time.Hour)
+	err := v.Validate(Config{TTL: 2 * time.Hour})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if err.Error() != "idem: ttl 2h0m0s exceeds maximum 1h0m0s" {
+		t.Errorf("unexpected default message: %q", err.Error())
+	}
+}
+
+func TestPresetValidator_WithMessage_nilOnSuccess(t *testing.T) {
+	t.Parallel()
+
+	v := MaxTTL(1 * time.Hour).WithMessage("custom error")
+	err := v.Validate(Config{TTL: 30 * time.Minute})
+	if err != nil {
+		t.Errorf("expected nil, got %v", err)
+	}
+}
+
+func TestPresetValidator_WithMessage_doesNotMutateOriginal(t *testing.T) {
+	t.Parallel()
+
+	original := MaxTTL(1 * time.Hour)
+	_ = original.WithMessage("custom error")
+
+	err := original.Validate(Config{TTL: 2 * time.Hour})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if err.Error() == "custom error" {
+		t.Error("WithMessage mutated the original validator")
+	}
+}
+
+func TestNew_withPresetValidatorWithMessage(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns custom error message", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := New(
+			WithTTL(48*time.Hour),
+			WithValidation(MaxTTL(24*time.Hour).WithMessage("TTL exceeds limit")),
+		)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if err.Error() != "TTL exceeds limit" {
+			t.Errorf("error = %q, want %q", err.Error(), "TTL exceeds limit")
+		}
+	})
+
+	t.Run("succeeds when validation passes with WithMessage set", func(t *testing.T) {
+		t.Parallel()
+
+		m, err := New(
+			WithTTL(1*time.Hour),
+			WithValidation(MaxTTL(24*time.Hour).WithMessage("TTL exceeds limit")),
 		)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)


### PR DESCRIPTION
## Summary
- Refactor `Validator` from function type (`func(Config) error`) to interface with `Validate(Config) error` method
- Add `ValidatorFunc` adapter following the `http.Handler`/`http.HandlerFunc` pattern
- Introduce `PresetValidator` struct with `WithMessage(msg)` method for custom error messages on built-in validators (`MaxTTL`, `MinTTL`, `TTLRange`, `KeyHeaderPattern`, `AllowedKeyHeaders`)
- `WithMessage` returns a copy, preserving immutability of the original validator
- Update README with `ValidatorFunc` usage and `WithMessage` examples
- Update CLAUDE.md with `Validator` interface documentation

## Test plan
- [x] All existing preset validator tests updated to use `.Validate()` method
- [x] All custom validator tests updated to use `ValidatorFunc` wrapper
- [x] `TestPresetValidator_WithMessage` — custom messages for all 5 presets
- [x] `TestPresetValidator_WithMessage_defaultMessageWithoutWithMessage` — default message preserved
- [x] `TestPresetValidator_WithMessage_nilOnSuccess` — no error on valid config
- [x] `TestPresetValidator_WithMessage_doesNotMutateOriginal` — copy semantics verified
- [x] `TestNew_withPresetValidatorWithMessage` — integration with `New()`
- [x] `go build ./...` passes
- [x] `go test ./... -short` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)