### PR TITLE
Replace PAT with GitHub App token in release workflow

### DIFF
--- a/.github/workflows/on-workflow-dispatch.yml
+++ b/.github/workflows/on-workflow-dispatch.yml
@@ -55,13 +55,15 @@ jobs:
           REPO: ${{ github.repository }}
           VERSION: ${{ inputs.version }}
         run: |
-          TAG_SHA=$(gh api "repos/$REPO/git/tags" \
-            -f tag="$VERSION" \
-            -f message="Release $VERSION" \
-            -f object="$GITHUB_SHA" \
-            -f type="commit" \
+          TAG_SHA=$(gh api "repos/${REPO}/git/tags" \
+            --method POST \
+            --field "tag=${VERSION}" \
+            --field "message=Release ${VERSION}" \
+            --field "object=${GITHUB_SHA}" \
+            --field "type=commit" \
             --jq '.sha')
 
-          gh api "repos/$REPO/git/refs" \
-            -f ref="refs/tags/$VERSION" \
-            -f sha="$TAG_SHA"
+          gh api "repos/${REPO}/git/refs" \
+            --method POST \
+            --field "ref=refs/tags/${VERSION}" \
+            --field "sha=${TAG_SHA}"


### PR DESCRIPTION
## Summary
- `on-workflow-dispatch.yml` の PAT (`AUTH_TOKEN`) を GitHub App (`chloe-chan-bot`) トークンに置き換え
- `actions/create-github-app-token@v2` でトークンを動的生成
- git config の名前・メールも GitHub App bot のものに変更

## 廃止可能なシークレット
- `AUTH_TOKEN`
- `BR_GITHUB_MANAGER_NAME`
- `BR_GITHUB_MANAGER_EMAIL`

## Test plan
- [ ] `workflow_dispatch` でリリースタグのプッシュが正常に動作すること
- [ ] 作成されたタグのコミッターが `chloe-chan-bot[bot]` になっていること

🤖 Generated with [Claude Code](https://claude.com/claude-code)