### PR TITLE
Close #147: Include OnErrorEnabled and ValidatorCount in Config.String()

### DIFF
--- a/option.go
+++ b/option.go
@@ -94,8 +94,8 @@ func (c *config) snapshot() Config {
 // String returns a human-readable summary of the configuration.
 func (c Config) String() string {
 	return fmt.Sprintf(
-		"idem.Config{KeyHeader: %q, TTL: %v, KeyMaxLength: %d, StorageType: %s, LockSupported: %t, MetricsEnabled: %t}",
-		c.KeyHeader, c.TTL, c.KeyMaxLength, c.StorageType, c.LockSupported, c.MetricsEnabled,
+		"idem.Config{KeyHeader: %q, TTL: %v, KeyMaxLength: %d, StorageType: %s, LockSupported: %t, MetricsEnabled: %t, OnErrorEnabled: %t, ValidatorCount: %d}",
+		c.KeyHeader, c.TTL, c.KeyMaxLength, c.StorageType, c.LockSupported, c.MetricsEnabled, c.OnErrorEnabled, c.ValidatorCount,
 	)
 }
 

--- a/option_test.go
+++ b/option_test.go
@@ -421,10 +421,16 @@ func TestConfig_String(t *testing.T) {
 			StorageType:    "*idem.MemoryStorage",
 			LockSupported:  true,
 			MetricsEnabled: true,
+			OnErrorEnabled: true,
+			ValidatorCount: 3,
 		}
 
 		s := cfg.String()
-		for _, want := range []string{"Idempotency-Key", "24h0m0s", "*idem.MemoryStorage", "true"} {
+		for _, want := range []string{
+			"Idempotency-Key", "24h0m0s", "*idem.MemoryStorage",
+			"LockSupported: true", "MetricsEnabled: true",
+			"OnErrorEnabled: true", "ValidatorCount: 3",
+		} {
 			if !strings.Contains(s, want) {
 				t.Errorf("String() = %q, missing %q", s, want)
 			}


### PR DESCRIPTION
## Summary
- Add `OnErrorEnabled` and `ValidatorCount` fields to `Config.String()` output to match JSON encoding
- Update `TestConfig_String` to verify the new fields are present

## Test plan
- [x] `TestConfig_String/contains_all_key_fields` verifies both new fields appear in output
- [x] `TestConfig_String/does_not_panic_on_zero_value` still passes with zero-value Config

🤖 Generated with [Claude Code](https://claude.com/claude-code)