### PR TITLE
Close #150: Align go.mod Go version with Dockerfile (1.26.1)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/bright-room/idem
 
-go 1.25.5
+go 1.26.1
 
 require github.com/redis/go-redis/v9 v9.18.0
 


### PR DESCRIPTION
## Summary
- `go.mod` の Go バージョンを `1.25.5` → `1.26.1` に更新し、Dockerfile (`golang:1.26.1`) と統一
- CI (`on-pull-request.yml`) は `go-version-file: go.mod` を参照しているため、自動的に全環境が Go 1.26.1 に統一される

## Test plan
- [ ] `go build ./...` がパスすること
- [ ] `go vet ./...` がパスすること
- [ ] `go test -short ./...` がパスすること
- [ ] CI の lint / unit test / integration test がパスすること

🤖 Generated with [Claude Code](https://claude.com/claude-code)