### PR TITLE
Close #99 Add Duration type with human-readable JSON serialization

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,6 +35,8 @@ Key interfaces:
 - `Locker` — optional per-key mutual exclusion for concurrent request handling. Storage implementations that also implement `Locker` enable automatic lock acquisition in the middleware. Returns 409 Conflict on lock failure.
 - `Validator` — `Validate(Config) error` for configuration validation. `ValidatorFunc` is a function adapter (like `http.HandlerFunc`). Preset validators (`MaxTTL`, `MinTTL`, etc.) return `*PresetValidator` which supports `.WithMessage()` for custom error messages. Composition functions `All` (AND) and `Any` (OR) combine multiple validators and also return `*PresetValidator`.
 
+- `Duration` — `time.Duration` wrapper with human-readable JSON serialization (e.g. `"1h0m0s"` instead of nanoseconds). Used in `Config.TTL`.
+
 Configuration uses the **Functional Options** pattern (`WithXxx()` functions).
 
 ## Conventions

--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ http.HandleFunc("/debug/idem/config", func(w http.ResponseWriter, r *http.Reques
 })
 ```
 
-The `Config` struct includes JSON tags and implements `fmt.Stringer` for convenient serialization.
+The `Config` struct includes JSON tags and implements `fmt.Stringer` for convenient serialization. The `TTL` field uses the `Duration` type, which serializes as a human-readable string (e.g. `"1h0m0s"`) instead of integer nanoseconds.
 
 ## Error Handling
 

--- a/duration.go
+++ b/duration.go
@@ -1,0 +1,37 @@
+package idem
+
+import (
+	"encoding/json"
+	"time"
+)
+
+// Duration is a [time.Duration] that serializes to and from a human-readable
+// string in JSON (e.g. "1h30m0s") instead of integer nanoseconds.
+type Duration time.Duration
+
+// MarshalJSON encodes d as a quoted duration string (e.g. "1h0m0s").
+func (d Duration) MarshalJSON() ([]byte, error) {
+	return json.Marshal(time.Duration(d).String())
+}
+
+// UnmarshalJSON decodes a quoted duration string (e.g. "1h0m0s") into d.
+func (d *Duration) UnmarshalJSON(b []byte) error {
+	var s string
+	if err := json.Unmarshal(b, &s); err != nil {
+		return err
+	}
+
+	parsed, err := time.ParseDuration(s)
+	if err != nil {
+		return err
+	}
+
+	*d = Duration(parsed)
+
+	return nil
+}
+
+// String returns the duration formatted as a string (e.g. "1h0m0s").
+func (d Duration) String() string {
+	return time.Duration(d).String()
+}

--- a/duration_test.go
+++ b/duration_test.go
@@ -1,0 +1,174 @@
+package idem
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+func TestDuration_MarshalJSON(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		d    Duration
+		want string
+	}{
+		{
+			name: "zero",
+			d:    0,
+			want: `"0s"`,
+		},
+		{
+			name: "24 hours",
+			d:    Duration(24 * time.Hour),
+			want: `"24h0m0s"`,
+		},
+		{
+			name: "5 minutes",
+			d:    Duration(5 * time.Minute),
+			want: `"5m0s"`,
+		},
+		{
+			name: "mixed",
+			d:    Duration(1*time.Hour + 30*time.Minute + 15*time.Second),
+			want: `"1h30m15s"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := json.Marshal(tt.d)
+			if err != nil {
+				t.Fatalf("MarshalJSON() error = %v", err)
+			}
+			if string(got) != tt.want {
+				t.Errorf("MarshalJSON() = %s, want %s", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDuration_UnmarshalJSON(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		input   string
+		want    Duration
+		wantErr bool
+	}{
+		{
+			name:  "zero",
+			input: `"0s"`,
+			want:  0,
+		},
+		{
+			name:  "24 hours",
+			input: `"24h0m0s"`,
+			want:  Duration(24 * time.Hour),
+		},
+		{
+			name:  "5 minutes shorthand",
+			input: `"5m"`,
+			want:  Duration(5 * time.Minute),
+		},
+		{
+			name:    "invalid string",
+			input:   `"invalid"`,
+			wantErr: true,
+		},
+		{
+			name:    "non-string value",
+			input:   `123`,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var got Duration
+			err := json.Unmarshal([]byte(tt.input), &got)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("UnmarshalJSON() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if !tt.wantErr && got != tt.want {
+				t.Errorf("UnmarshalJSON() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDuration_String(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		d    Duration
+		want string
+	}{
+		{
+			name: "zero",
+			d:    0,
+			want: "0s",
+		},
+		{
+			name: "24 hours",
+			d:    Duration(24 * time.Hour),
+			want: "24h0m0s",
+		},
+		{
+			name: "5 minutes",
+			d:    Duration(5 * time.Minute),
+			want: "5m0s",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := tt.d.String(); got != tt.want {
+				t.Errorf("String() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDuration_roundTrip(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		d    Duration
+	}{
+		{name: "zero", d: 0},
+		{name: "1 hour", d: Duration(1 * time.Hour)},
+		{name: "24 hours", d: Duration(24 * time.Hour)},
+		{name: "complex", d: Duration(2*time.Hour + 15*time.Minute + 30*time.Second)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			b, err := json.Marshal(tt.d)
+			if err != nil {
+				t.Fatalf("Marshal error = %v", err)
+			}
+
+			var got Duration
+			if err := json.Unmarshal(b, &got); err != nil {
+				t.Fatalf("Unmarshal error = %v", err)
+			}
+
+			if got != tt.d {
+				t.Errorf("round-trip = %v, want %v", got, tt.d)
+			}
+		})
+	}
+}

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -763,7 +763,7 @@ func TestMiddleware_Config(t *testing.T) {
 		if cfg.KeyHeader != DefaultKeyHeader {
 			t.Errorf("KeyHeader = %q, want %q", cfg.KeyHeader, DefaultKeyHeader)
 		}
-		if cfg.TTL != DefaultTTL {
+		if cfg.TTL != Duration(DefaultTTL) {
 			t.Errorf("TTL = %v, want %v", cfg.TTL, DefaultTTL)
 		}
 		if cfg.StorageType != "*idem.MemoryStorage" {
@@ -803,7 +803,7 @@ func TestMiddleware_Config(t *testing.T) {
 		if cfg.KeyHeader != "X-Request-Id" {
 			t.Errorf("KeyHeader = %q, want %q", cfg.KeyHeader, "X-Request-Id")
 		}
-		if cfg.TTL != 5*time.Minute {
+		if cfg.TTL != Duration(5*time.Minute) {
 			t.Errorf("TTL = %v, want %v", cfg.TTL, 5*time.Minute)
 		}
 		if cfg.StorageType != "*idem.stubStorage" {
@@ -860,9 +860,8 @@ func TestMiddleware_ConfigHandler(t *testing.T) {
 			t.Errorf("Content-Type = %q, want %q", ct, "application/json")
 		}
 
-		// json.Decode deserializes time.Duration as an integer (nanoseconds).
-		// This round-trip works because Config uses the default json tag
-		// without a custom MarshalJSON implementation.
+		// Duration.UnmarshalJSON decodes the human-readable string (e.g. "24h0m0s")
+		// produced by Duration.MarshalJSON, so the round-trip preserves the value.
 		var got Config
 		if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
 			t.Fatalf("failed to decode response: %v", err)
@@ -900,7 +899,7 @@ func TestMiddleware_ConfigHandler(t *testing.T) {
 		if got.KeyHeader != "X-Request-Id" {
 			t.Errorf("KeyHeader = %q, want %q", got.KeyHeader, "X-Request-Id")
 		}
-		if got.TTL != 5*time.Minute {
+		if got.TTL != Duration(5*time.Minute) {
 			t.Errorf("TTL = %v, want %v", got.TTL, 5*time.Minute)
 		}
 		if got.KeyMaxLength != 64 {

--- a/option.go
+++ b/option.go
@@ -24,7 +24,7 @@ type Config struct {
 	KeyHeader string `json:"key_header"`
 
 	// TTL is the time-to-live for cached responses.
-	TTL time.Duration `json:"ttl"`
+	TTL Duration `json:"ttl"`
 
 	// KeyMaxLength is the maximum allowed length for idempotency key values.
 	// A value of 0 means no length limit.
@@ -75,7 +75,7 @@ type config struct {
 func (c *config) snapshot() Config {
 	cfg := Config{
 		KeyHeader:      c.keyHeader,
-		TTL:            c.ttl,
+		TTL:            Duration(c.ttl),
 		KeyMaxLength:   c.keyMaxLength,
 		ValidatorCount: len(c.validators),
 	}

--- a/option_test.go
+++ b/option_test.go
@@ -232,7 +232,7 @@ func TestConfig_validate(t *testing.T) {
 					if cfg.KeyHeader != "X-Test" {
 						return errors.New("unexpected KeyHeader")
 					}
-					if cfg.TTL != 5*time.Minute {
+					if cfg.TTL != Duration(5*time.Minute) {
 						return errors.New("unexpected TTL")
 					}
 					return nil
@@ -310,7 +310,7 @@ func TestConfig_snapshot(t *testing.T) {
 		if snap.KeyHeader != cfg.keyHeader {
 			t.Errorf("KeyHeader = %q, want %q", snap.KeyHeader, cfg.keyHeader)
 		}
-		if snap.TTL != cfg.ttl {
+		if snap.TTL != Duration(cfg.ttl) {
 			t.Errorf("TTL = %v, want %v", snap.TTL, cfg.ttl)
 		}
 	})
@@ -417,7 +417,7 @@ func TestConfig_String(t *testing.T) {
 
 		cfg := Config{
 			KeyHeader:      "Idempotency-Key",
-			TTL:            24 * time.Hour,
+			TTL:            Duration(24 * time.Hour),
 			StorageType:    "*idem.MemoryStorage",
 			LockSupported:  true,
 			MetricsEnabled: true,

--- a/validator.go
+++ b/validator.go
@@ -41,7 +41,7 @@ func (p *PresetValidator) WithMessage(msg string) *PresetValidator {
 func MaxTTL(limit time.Duration) *PresetValidator {
 	return &PresetValidator{
 		validate: func(cfg Config) error {
-			if cfg.TTL > limit {
+			if cfg.TTL > Duration(limit) {
 				return fmt.Errorf("idem: ttl %v exceeds maximum %v", cfg.TTL, limit)
 			}
 			return nil
@@ -53,7 +53,7 @@ func MaxTTL(limit time.Duration) *PresetValidator {
 func MinTTL(limit time.Duration) *PresetValidator {
 	return &PresetValidator{
 		validate: func(cfg Config) error {
-			if cfg.TTL < limit {
+			if cfg.TTL < Duration(limit) {
 				return fmt.Errorf("idem: ttl %v is shorter than minimum %v", cfg.TTL, limit)
 			}
 			return nil
@@ -68,7 +68,7 @@ func TTLRange(lower, upper time.Duration) *PresetValidator {
 			if lower > upper {
 				return ErrInvalidTTLRange
 			}
-			if cfg.TTL < lower || cfg.TTL > upper {
+			if cfg.TTL < Duration(lower) || cfg.TTL > Duration(upper) {
 				return fmt.Errorf("idem: ttl %v is out of range [%v, %v]", cfg.TTL, lower, upper)
 			}
 			return nil

--- a/validator_test.go
+++ b/validator_test.go
@@ -41,7 +41,7 @@ func TestMaxTTL(t *testing.T) {
 			t.Parallel()
 
 			v := MaxTTL(tt.max)
-			err := v.Validate(Config{KeyHeader: DefaultKeyHeader, TTL: tt.ttl})
+			err := v.Validate(Config{KeyHeader: DefaultKeyHeader, TTL: Duration(tt.ttl)})
 			if (err != nil) != tt.wantErr {
 				t.Errorf("MaxTTL(%v)() error = %v, wantErr %v", tt.max, err, tt.wantErr)
 			}
@@ -83,7 +83,7 @@ func TestMinTTL(t *testing.T) {
 			t.Parallel()
 
 			v := MinTTL(tt.min)
-			err := v.Validate(Config{KeyHeader: DefaultKeyHeader, TTL: tt.ttl})
+			err := v.Validate(Config{KeyHeader: DefaultKeyHeader, TTL: Duration(tt.ttl)})
 			if (err != nil) != tt.wantErr {
 				t.Errorf("MinTTL(%v)() error = %v, wantErr %v", tt.min, err, tt.wantErr)
 			}
@@ -166,7 +166,7 @@ func TestTTLRange(t *testing.T) {
 			t.Parallel()
 
 			v := TTLRange(tt.min, tt.max)
-			err := v.Validate(Config{KeyHeader: DefaultKeyHeader, TTL: tt.ttl})
+			err := v.Validate(Config{KeyHeader: DefaultKeyHeader, TTL: Duration(tt.ttl)})
 			if (err != nil) != tt.wantErr {
 				t.Errorf("TTLRange(%v, %v)() error = %v, wantErr %v", tt.min, tt.max, err, tt.wantErr)
 			}
@@ -210,7 +210,7 @@ func TestKeyHeaderPattern(t *testing.T) {
 			t.Parallel()
 
 			v := KeyHeaderPattern(tt.pattern)
-			err := v.Validate(Config{KeyHeader: tt.keyHeader, TTL: DefaultTTL})
+			err := v.Validate(Config{KeyHeader: tt.keyHeader, TTL: Duration(DefaultTTL)})
 			if (err != nil) != tt.wantErr {
 				t.Errorf("KeyHeaderPattern(%s)() error = %v, wantErr %v", tt.pattern, err, tt.wantErr)
 			}
@@ -258,7 +258,7 @@ func TestAllowedKeyHeaders(t *testing.T) {
 			t.Parallel()
 
 			v := AllowedKeyHeaders(tt.allowed...)
-			err := v.Validate(Config{KeyHeader: tt.keyHeader, TTL: DefaultTTL})
+			err := v.Validate(Config{KeyHeader: tt.keyHeader, TTL: Duration(DefaultTTL)})
 			if (err != nil) != tt.wantErr {
 				t.Errorf("AllowedKeyHeaders(%v)() error = %v, wantErr %v", tt.allowed, err, tt.wantErr)
 			}
@@ -394,31 +394,31 @@ func TestPresetValidator_WithMessage(t *testing.T) {
 		{
 			name:    "MaxTTL with custom message",
 			v:       MaxTTL(1 * time.Hour).WithMessage("TTL is too long for this service"),
-			cfg:     Config{TTL: 2 * time.Hour},
+			cfg:     Config{TTL: Duration(2 * time.Hour)},
 			wantMsg: "TTL is too long for this service",
 		},
 		{
 			name:    "MinTTL with custom message",
 			v:       MinTTL(1 * time.Hour).WithMessage("TTL is too short"),
-			cfg:     Config{TTL: 30 * time.Minute},
+			cfg:     Config{TTL: Duration(30 * time.Minute)},
 			wantMsg: "TTL is too short",
 		},
 		{
 			name:    "TTLRange with custom message",
 			v:       TTLRange(1*time.Minute, 1*time.Hour).WithMessage("TTL out of acceptable range"),
-			cfg:     Config{TTL: 2 * time.Hour},
+			cfg:     Config{TTL: Duration(2 * time.Hour)},
 			wantMsg: "TTL out of acceptable range",
 		},
 		{
 			name:    "KeyHeaderPattern with custom message",
 			v:       KeyHeaderPattern(regexp.MustCompile(`^X-`)).WithMessage("header must start with X-"),
-			cfg:     Config{KeyHeader: "Idempotency-Key", TTL: DefaultTTL},
+			cfg:     Config{KeyHeader: "Idempotency-Key", TTL: Duration(DefaultTTL)},
 			wantMsg: "header must start with X-",
 		},
 		{
 			name:    "AllowedKeyHeaders with custom message",
 			v:       AllowedKeyHeaders("Idempotency-Key").WithMessage("unsupported header"),
-			cfg:     Config{KeyHeader: "X-Custom", TTL: DefaultTTL},
+			cfg:     Config{KeyHeader: "X-Custom", TTL: Duration(DefaultTTL)},
 			wantMsg: "unsupported header",
 		},
 	}
@@ -442,7 +442,7 @@ func TestPresetValidator_WithMessage_defaultMessageWithoutWithMessage(t *testing
 	t.Parallel()
 
 	v := MaxTTL(1 * time.Hour)
-	err := v.Validate(Config{TTL: 2 * time.Hour})
+	err := v.Validate(Config{TTL: Duration(2 * time.Hour)})
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
@@ -455,7 +455,7 @@ func TestPresetValidator_WithMessage_nilOnSuccess(t *testing.T) {
 	t.Parallel()
 
 	v := MaxTTL(1 * time.Hour).WithMessage("custom error")
-	err := v.Validate(Config{TTL: 30 * time.Minute})
+	err := v.Validate(Config{TTL: Duration(30 * time.Minute)})
 	if err != nil {
 		t.Errorf("expected nil, got %v", err)
 	}
@@ -467,7 +467,7 @@ func TestPresetValidator_WithMessage_doesNotMutateOriginal(t *testing.T) {
 	original := MaxTTL(1 * time.Hour)
 	_ = original.WithMessage("custom error")
 
-	err := original.Validate(Config{TTL: 2 * time.Hour})
+	err := original.Validate(Config{TTL: Duration(2 * time.Hour)})
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
@@ -529,7 +529,7 @@ func TestAll(t *testing.T) {
 			t.Parallel()
 
 			v := All(tt.validators...)
-			err := v.Validate(Config{KeyHeader: DefaultKeyHeader, TTL: DefaultTTL})
+			err := v.Validate(Config{KeyHeader: DefaultKeyHeader, TTL: Duration(DefaultTTL)})
 			if (err != nil) != tt.wantErr {
 				t.Errorf("All() error = %v, wantErr %v", err, tt.wantErr)
 			}
@@ -546,7 +546,7 @@ func TestAll_WithMessage(t *testing.T) {
 	alwaysFail := ValidatorFunc(func(_ Config) error { return errors.New("fail") })
 
 	v := All(alwaysFail).WithMessage("custom all error")
-	err := v.Validate(Config{KeyHeader: DefaultKeyHeader, TTL: DefaultTTL})
+	err := v.Validate(Config{KeyHeader: DefaultKeyHeader, TTL: Duration(DefaultTTL)})
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
@@ -612,7 +612,7 @@ func TestAny(t *testing.T) {
 			t.Parallel()
 
 			v := Any(tt.validators...)
-			err := v.Validate(Config{KeyHeader: DefaultKeyHeader, TTL: DefaultTTL})
+			err := v.Validate(Config{KeyHeader: DefaultKeyHeader, TTL: Duration(DefaultTTL)})
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Any() error = %v, wantErr %v", err, tt.wantErr)
 			}
@@ -629,7 +629,7 @@ func TestAny_WithMessage(t *testing.T) {
 	alwaysFail := ValidatorFunc(func(_ Config) error { return errors.New("fail") })
 
 	v := Any(alwaysFail).WithMessage("custom any error")
-	err := v.Validate(Config{KeyHeader: DefaultKeyHeader, TTL: DefaultTTL})
+	err := v.Validate(Config{KeyHeader: DefaultKeyHeader, TTL: Duration(DefaultTTL)})
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
@@ -648,7 +648,7 @@ func TestAll_Any_nested(t *testing.T) {
 		t.Parallel()
 
 		v := All(Any(alwaysFail, alwaysPass), alwaysPass)
-		err := v.Validate(Config{KeyHeader: DefaultKeyHeader, TTL: DefaultTTL})
+		err := v.Validate(Config{KeyHeader: DefaultKeyHeader, TTL: Duration(DefaultTTL)})
 		if err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}
@@ -658,7 +658,7 @@ func TestAll_Any_nested(t *testing.T) {
 		t.Parallel()
 
 		v := All(Any(alwaysFail, alwaysFail), alwaysPass)
-		err := v.Validate(Config{KeyHeader: DefaultKeyHeader, TTL: DefaultTTL})
+		err := v.Validate(Config{KeyHeader: DefaultKeyHeader, TTL: Duration(DefaultTTL)})
 		if err == nil {
 			t.Fatal("expected error, got nil")
 		}
@@ -668,7 +668,7 @@ func TestAll_Any_nested(t *testing.T) {
 		t.Parallel()
 
 		v := Any(All(alwaysFail, alwaysPass), alwaysPass)
-		err := v.Validate(Config{KeyHeader: DefaultKeyHeader, TTL: DefaultTTL})
+		err := v.Validate(Config{KeyHeader: DefaultKeyHeader, TTL: Duration(DefaultTTL)})
 		if err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}
@@ -678,7 +678,7 @@ func TestAll_Any_nested(t *testing.T) {
 		t.Parallel()
 
 		v := Any(All(alwaysFail, alwaysPass), alwaysFail)
-		err := v.Validate(Config{KeyHeader: DefaultKeyHeader, TTL: DefaultTTL})
+		err := v.Validate(Config{KeyHeader: DefaultKeyHeader, TTL: Duration(DefaultTTL)})
 		if err == nil {
 			t.Fatal("expected error, got nil")
 		}
@@ -692,7 +692,7 @@ func TestAll_WithMessage_doesNotMutateOriginal(t *testing.T) {
 	original := All(alwaysFail)
 	_ = original.WithMessage("custom")
 
-	err := original.Validate(Config{KeyHeader: DefaultKeyHeader, TTL: DefaultTTL})
+	err := original.Validate(Config{KeyHeader: DefaultKeyHeader, TTL: Duration(DefaultTTL)})
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
@@ -708,7 +708,7 @@ func TestAny_WithMessage_doesNotMutateOriginal(t *testing.T) {
 	original := Any(alwaysFail)
 	_ = original.WithMessage("custom")
 
-	err := original.Validate(Config{KeyHeader: DefaultKeyHeader, TTL: DefaultTTL})
+	err := original.Validate(Config{KeyHeader: DefaultKeyHeader, TTL: Duration(DefaultTTL)})
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}


### PR DESCRIPTION
## Summary
- Add `Duration` type (`type Duration time.Duration`) with custom `MarshalJSON`/`UnmarshalJSON` that outputs human-readable strings (e.g. `"24h0m0s"`) instead of integer nanoseconds
- Replace `Config.TTL` type from `time.Duration` to `Duration` for readable `ConfigHandler()` JSON output
- Update validators (`MaxTTL`, `MinTTL`, `TTLRange`) to compare with `Duration` type internally

Closes #99

## Test plan
- [x] `Duration.MarshalJSON` produces quoted duration strings
- [x] `Duration.UnmarshalJSON` parses duration strings and rejects invalid input
- [x] `Duration.String` matches `time.Duration.String` output
- [x] Marshal → Unmarshal round-trip preserves values
- [x] All existing validator tests pass with `Duration` type
- [x] `ConfigHandler` JSON round-trip works with string-based TTL
- [x] `make lint` passes with 0 issues
- [x] `make test-unit` passes (302 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)